### PR TITLE
ci: add build & test workflow and CI/CD documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,62 @@
+name: Build & Test
+
+on:
+  push:
+    branches: ['**']
+    paths:
+      - 'lib/**'
+      - '*.gradle.kts'
+      - 'gradle/**'
+      - 'gradlew*'
+      - '.github/workflows/build.yml'
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'lib/**'
+      - '*.gradle.kts'
+      - 'gradle/**'
+      - 'gradlew*'
+      - '.github/workflows/build.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Check formatting
+        run: ./gradlew spotlessCheck
+
+      - name: Assemble
+        run: ./gradlew assemble
+
+      - name: Run tests
+        run: ./gradlew test
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: lib/build/reports/tests/test/
+          retention-days: 14

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -1,0 +1,43 @@
+# CI/CD
+
+This project uses GitHub Actions for continuous integration and delivery.
+
+## Workflows
+
+| Workflow | File | Purpose |
+|----------|------|---------|
+| Build & Test | `.github/workflows/build.yml` | Formatting checks, compilation, and test suite |
+
+## Build & Test
+
+Runs `spotlessCheck`, `assemble`, and `test` on every push and pull request that touches code-relevant files. Documentation-only changes are skipped via path filters.
+
+If a new commit is pushed while a run is already in progress for the same branch, the older run is automatically cancelled.
+
+### Reading CI results
+
+1. **Status check on PRs** — the workflow result appears as a check on the pull request page.
+2. **Actions tab** — navigate to the repository's Actions tab to see all workflow runs.
+3. **Test report artifact** — every run uploads an HTML test report. Download it from the Artifacts section of the workflow run summary (retained for 14 days).
+
+### Troubleshooting
+
+#### Formatting check failed
+
+The `spotlessCheck` step enforces Google Java Format. To fix locally:
+
+```bash
+./gradlew spotlessApply
+```
+
+This reformats all source files in place. Commit the changes and push again.
+
+#### Test failure
+
+Check the uploaded test report artifact for details:
+
+1. Go to the failed workflow run in the Actions tab.
+2. Scroll to the **Artifacts** section.
+3. Download **test-report** and open `index.html` in a browser.
+
+The report shows which tests failed, with stack traces and assertion messages.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,7 @@
+# Hypernate Documentation
+
+Hypernate is an entity framework for Hyperledger Fabric that brings ORM-like convenience to chaincode development. It provides object-oriented CRUD operations, declarative entity key configuration, and an extensible middleware chain.
+
+## Pages
+
+- [CI/CD](cicd.md) — Continuous integration and delivery workflows


### PR DESCRIPTION
Add GitHub Actions workflow that runs Spotless formatting checks and Gradle build/test on code changes. Include docs/ directory with modular layout and CI/CD documentation page.

Job logs on fork: https://github.com/aklenik/hypernate/actions/runs/24124725991/job/70386486743

Closes #19 