### PR TITLE
feat: add explicit type support to AttributeInfo

### DIFF
--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/annotations/AttributeInfo.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/annotations/AttributeInfo.java
@@ -8,4 +8,6 @@ public @interface AttributeInfo {
   String name();
 
   Class<? extends AttributeMapper> mapper() default ObjectToString.class;
+
+  Class<?> type() default Object.class;
 }

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java
@@ -4,6 +4,10 @@ package hu.bme.mit.ftsrg.hypernate.registry;
 import com.jcabi.aspects.Loggable;
 import hu.bme.mit.ftsrg.hypernate.annotations.AttributeInfo;
 import hu.bme.mit.ftsrg.hypernate.annotations.PrimaryKey;
+import hu.bme.mit.ftsrg.hypernate.mappers.AttributeMapper;
+import hu.bme.mit.ftsrg.hypernate.mappers.IntegerZeroPadder;
+import hu.bme.mit.ftsrg.hypernate.mappers.LongZeroPadder;
+import hu.bme.mit.ftsrg.hypernate.mappers.ObjectToString;
 import hu.bme.mit.ftsrg.hypernate.util.JSON;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -241,6 +245,18 @@ public class Registry {
 
     private final Logger logger = LoggerFactory.getLogger(EntityUtil.class);
 
+    private final Map<Class<?>, Class<? extends AttributeMapper>> DEFAULT_MAPPERS_BY_TYPE =
+        Map.of(
+            String.class, ObjectToString.class,
+            Integer.class, IntegerZeroPadder.class,
+            Long.class, LongZeroPadder.class);
+
+    private final Map<Class<? extends AttributeMapper>, Class<?>> EXPECTED_TYPES_BY_MAPPER =
+        Map.of(
+            IntegerZeroPadder.class, Integer.class,
+            LongZeroPadder.class, Long.class,
+            ObjectToString.class, Object.class);
+
     <T> String getType(final T entity) {
       return getType(entity.getClass());
     }
@@ -308,6 +324,25 @@ public class Registry {
 
     private String applyAttrMapper(final AttributeInfo attrInfo, final Object keyPart) {
       Class<? extends Function<Object, String>> mapperClass = attrInfo.mapper();
+      Class<?> declaredType = attrInfo.type();
+
+      if (declaredType != Object.class && mapperClass == ObjectToString.class) {
+        Class<? extends AttributeMapper> inferred = DEFAULT_MAPPERS_BY_TYPE.get(declaredType);
+        if (inferred != null) {
+          mapperClass = inferred;
+        }
+      }
+
+      if (declaredType != Object.class) {
+        Class<?> expectedType = EXPECTED_TYPES_BY_MAPPER.get(mapperClass);
+        if (expectedType != null && !expectedType.isAssignableFrom(declaredType)) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "Mapper %s is not compatible with declared type %s for attribute %s",
+                  mapperClass.getName(), declaredType.getName(), attrInfo.name()));
+        }
+      }
+
       Constructor<? extends Function<Object, String>> mapperCtor;
       try {
         mapperCtor = mapperClass.getDeclaredConstructor();

--- a/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/annotations/AttributeInfoTypeTest.java
+++ b/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/annotations/AttributeInfoTypeTest.java
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.annotations;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import hu.bme.mit.ftsrg.hypernate.mappers.IntegerZeroPadder;
+import hu.bme.mit.ftsrg.hypernate.registry.Registry;
+import org.hyperledger.fabric.shim.ChaincodeStub;
+import org.hyperledger.fabric.shim.ledger.CompositeKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AttributeInfoTypeTest {
+
+  @Mock private ChaincodeStub stub;
+  private Registry registry;
+
+  @BeforeEach
+  void setup() {
+    registry = new Registry(stub);
+  }
+
+  @PrimaryKey({@AttributeInfo(name = "id")})
+  record LegacyEntity(String id) {}
+
+  @Test
+  void legacyCompatibility() {
+    given(stub.createCompositeKey(anyString(), any(String[].class)))
+        .willReturn(new CompositeKey("fake"));
+    given(stub.getState(anyString())).willReturn(new byte[] {});
+    assertTrue(registry.tryCreate(new LegacyEntity("test")));
+  }
+
+  @PrimaryKey({@AttributeInfo(name = "val", type = Integer.class, mapper = IntegerZeroPadder.class)})
+  record ValidEntity(Integer val) {}
+
+  @Test
+  void validExplicitMapper() {
+    given(stub.createCompositeKey(anyString(), any(String[].class)))
+        .willReturn(new CompositeKey("fake"));
+    given(stub.getState(anyString())).willReturn(new byte[] {});
+    assertTrue(registry.tryCreate(new ValidEntity(42)));
+  }
+
+  @PrimaryKey({@AttributeInfo(name = "val", type = String.class, mapper = IntegerZeroPadder.class)})
+  record InvalidEntity(String val) {}
+
+  @Test
+  void invalidExplicitMapper() {
+    assertThrows(IllegalArgumentException.class, () -> registry.tryCreate(new InvalidEntity("42")));
+  }
+
+  @PrimaryKey({@AttributeInfo(name = "val", type = Integer.class)})
+  record InferredEntity(Integer val) {}
+
+  @Test
+  void defaultMapperInference() {
+    given(stub.createCompositeKey(anyString(), any(String[].class)))
+        .willAnswer(inv -> {
+            String[] args = inv.getArgument(1);
+            if (args[0].length() == 10) { 
+                return new CompositeKey("fake");
+            }
+            throw new RuntimeException("Inference failed, expected padded key, got: " + args[0]);
+        });
+    given(stub.getState(anyString())).willReturn(new byte[] {});
+    assertTrue(registry.tryCreate(new InferredEntity(42)));
+  }
+}


### PR DESCRIPTION
Fixes #33

- Added explicit `type` field to @AttributeInfo (default: Object.class)
- Implemented type–mapper compatibility validation
- Added default mapper inference based on type
- Preserved backward compatibility with existing usage
- Added tests for legacy, valid, invalid, and inference cases