### PR TITLE
Add EntityType annotation and update Registry to support explicit entity types

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,22 @@ public record Asset(
     String owner) {}
 ```
 
+#### Declaring a stable entity type
+
+By default, Hypernate uses the entity class name as the composite key object type.
+To decouple the ledger key space from Java package/class renaming, define an explicit entity type with `@EntityType`:
+
+```java
+@EntityType("Asset")
+@PrimaryKey(@AttributeInfo(name = Asset.Fields.assetID))
+public record Asset(
+    String assetID,
+    String color,
+    int size,
+    int appraisedValue,
+    String owner) {}
+```
+
 #### Polishing your primary key with mappers
 
 In the end, Fabric expects a string value as an entity key and the previous example used a string valued attribute as key (part), so all is good (hopefully).

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/annotations/EntityType.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/annotations/EntityType.java
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface EntityType {
+  String value();
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/annotations/EntityType.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/annotations/EntityType.java
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Defines the explicit entity type name of the annotated class to be used for Registry composite
+ * keys.
+ *
+ * <p>This annotation is optional. In its absence, the entity type name defaults to the fully
+ * qualified class name (FQCN) returned by {@link Class#getName()}.
+ *
+ * <p>Specifying a stable, explicit name is recommended to decouple the keys in the ledger from
+ * potential Java class/package renames.
+ *
+ * <p>Example:
+ *
+ * <pre>{@code
+ * @EntityType("Asset")
+ * @PrimaryKey(@AttributeInfo(name = Asset.Fields.id))
+ * public record Asset(String id, String color, int size) {}
+ * }</pre>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface EntityType {
+  String value();
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java
@@ -3,6 +3,7 @@ package hu.bme.mit.ftsrg.hypernate.registry;
 
 import com.jcabi.aspects.Loggable;
 import hu.bme.mit.ftsrg.hypernate.annotations.AttributeInfo;
+import hu.bme.mit.ftsrg.hypernate.annotations.EntityType;
 import hu.bme.mit.ftsrg.hypernate.annotations.PrimaryKey;
 import hu.bme.mit.ftsrg.hypernate.util.JSON;
 import java.lang.reflect.Constructor;
@@ -246,7 +247,8 @@ public class Registry {
     }
 
     <T> String getType(final Class<T> clazz) {
-      return clazz.getName().toUpperCase();
+      final EntityType annot = clazz.getAnnotation(EntityType.class);
+      return annot != null ? annot.value() : clazz.getName();
     }
 
     <T> int getPrimaryKeyCount(final Class<T> clazz) {

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java
@@ -248,7 +248,18 @@ public class Registry {
 
     <T> String getType(final Class<T> clazz) {
       final EntityType annot = clazz.getAnnotation(EntityType.class);
-      return annot != null ? annot.value() : clazz.getName();
+      if (annot == null) {
+        return clazz.getName();
+      }
+
+      final String value = annot.value();
+      if (value.isBlank()) {
+        throw new IllegalArgumentException(
+            String.format(
+                "The @EntityType annotation on class %s has an empty or blank value",
+                clazz.getName()));
+      }
+      return value;
     }
 
     <T> int getPrimaryKeyCount(final Class<T> clazz) {

--- a/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/RegistryTest.java
+++ b/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/RegistryTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import hu.bme.mit.ftsrg.hypernate.annotations.AttributeInfo;
+import hu.bme.mit.ftsrg.hypernate.annotations.EntityType;
 import hu.bme.mit.ftsrg.hypernate.annotations.PrimaryKey;
 import hu.bme.mit.ftsrg.hypernate.registry.EntityExistsException;
 import hu.bme.mit.ftsrg.hypernate.registry.EntityNotFoundException;
@@ -88,6 +89,11 @@ class RegistryTest {
     @AttributeInfo(name = TestEntity.Fields.bar)
   })
   private record TestEntity(String foo, Integer bar) {}
+
+  @FieldNameConstants
+  @EntityType("Asset")
+  @PrimaryKey(@AttributeInfo(name = AnnotatedEntity.Fields.id))
+  private record AnnotatedEntity(String id) {}
 
   @Nested
   class when_must_create {
@@ -286,6 +292,7 @@ class RegistryTest {
 
       List<TestEntity> results = registry.readAll(TestEntity.class);
 
+      then(stub).should().createCompositeKey(TestEntity.class.getName());
       then(stub).should().getStateByPartialCompositeKey(anyString());
       assertTrue(results.isEmpty());
       verifyNoMoreInteractions(stub);
@@ -366,6 +373,19 @@ class RegistryTest {
       assertThrows(
           EntityNotFoundException.class,
           () -> registry.mustRead(TestEntity.class, entity.foo, entity.bar));
+      verifyNoMoreInteractions(stub);
+    }
+
+    @Test
+    void given_annotated_entity_type_then_use_annotation_value_for_composite_key() {
+      given(stub.createCompositeKey(anyString(), any(String[].class)))
+          .willReturn(new CompositeKey("Asset", "id-1"));
+      given(stub.getState(anyString())).willReturn(new byte[] {});
+
+      assertThrows(
+          EntityNotFoundException.class, () -> registry.mustRead(AnnotatedEntity.class, "id-1"));
+
+      then(stub).should().createCompositeKey(eq("Asset"), any(String[].class));
       verifyNoMoreInteractions(stub);
     }
 

--- a/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/RegistryTest.java
+++ b/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/RegistryTest.java
@@ -95,6 +95,16 @@ class RegistryTest {
   @PrimaryKey(@AttributeInfo(name = AnnotatedEntity.Fields.id))
   private record AnnotatedEntity(String id) {}
 
+  @FieldNameConstants
+  @EntityType("")
+  @PrimaryKey(@AttributeInfo(name = EmptyEntityTypeEntity.Fields.id))
+  private record EmptyEntityTypeEntity(String id) {}
+
+  @FieldNameConstants
+  @EntityType("   ")
+  @PrimaryKey(@AttributeInfo(name = BlankEntityTypeEntity.Fields.id))
+  private record BlankEntityTypeEntity(String id) {}
+
   @Nested
   class when_must_create {
 
@@ -395,6 +405,25 @@ class RegistryTest {
     }
 
     @Test
+    void given_no_entity_type_annotation_then_use_fqcn_for_composite_key() {
+      // Mock the stub to return a CompositeKey when asked, and represent an empty ledger
+      given(stub.createCompositeKey(anyString(), any(String[].class)))
+          .willReturn(new CompositeKey(TestEntity.class.getName(), "fooValue", "110"));
+      given(stub.getState(anyString())).willReturn(new byte[] {});
+
+      // This mustRead call is expected to fail with EntityNotFoundException because the ledger
+      // is empty. We are only executing mustRead here to force the call to key generation
+      // (which calls createCompositeKey internally) so that we can verify the key type name.
+      assertThrows(
+          EntityNotFoundException.class,
+          () -> registry.mustRead(TestEntity.class, entity.foo, entity.bar));
+
+      // Verify that the FQCN (not uppercased) was indeed used for creating the composite key
+      then(stub).should().createCompositeKey(eq(TestEntity.class.getName()), any(String[].class));
+      verifyNoMoreInteractions(stub);
+    }
+
+    @Test
     void given_existing_entity_with_insufficient_key_parts_then_throw_illegal_argument() {
       assertThrows(
           IllegalArgumentException.class, () -> registry.mustRead(TestEntity.class, entity.foo));
@@ -456,6 +485,26 @@ class RegistryTest {
 
       then(stub).should().getState(ENTITY_COMPOSITE_KEY_STR);
       assertEquals(entity, result);
+      verifyNoMoreInteractions(stub);
+    }
+  }
+
+  @Nested
+  class when_entity_type_is_invalid {
+
+    @Test
+    void given_empty_entity_type_annotation_value_then_throw_illegal_argument() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> registry.tryRead(EmptyEntityTypeEntity.class, "id-1"));
+      verifyNoMoreInteractions(stub);
+    }
+
+    @Test
+    void given_blank_entity_type_annotation_value_then_throw_illegal_argument() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> registry.tryRead(BlankEntityTypeEntity.class, "id-1"));
       verifyNoMoreInteractions(stub);
     }
   }

--- a/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/RegistryTest.java
+++ b/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/RegistryTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import hu.bme.mit.ftsrg.hypernate.annotations.AttributeInfo;
+import hu.bme.mit.ftsrg.hypernate.annotations.EntityType;
 import hu.bme.mit.ftsrg.hypernate.annotations.PrimaryKey;
 import hu.bme.mit.ftsrg.hypernate.registry.EntityExistsException;
 import hu.bme.mit.ftsrg.hypernate.registry.EntityNotFoundException;
@@ -88,6 +89,11 @@ class RegistryTest {
     @AttributeInfo(name = TestEntity.Fields.bar)
   })
   private record TestEntity(String foo, Integer bar) {}
+
+  @FieldNameConstants
+  @EntityType("Asset")
+  @PrimaryKey(@AttributeInfo(name = AnnotatedEntity.Fields.id))
+  private record AnnotatedEntity(String id) {}
 
   @Nested
   class when_must_create {
@@ -366,6 +372,25 @@ class RegistryTest {
       assertThrows(
           EntityNotFoundException.class,
           () -> registry.mustRead(TestEntity.class, entity.foo, entity.bar));
+      verifyNoMoreInteractions(stub);
+    }
+
+    @Test
+    void given_annotated_entity_type_then_use_annotation_value_for_composite_key() {
+      // Mock the stub to return a CompositeKey when asked, and represent an empty ledger
+      given(stub.createCompositeKey(anyString(), any(String[].class)))
+          .willReturn(new CompositeKey("Asset", "id-1"));
+      given(stub.getState(anyString())).willReturn(new byte[] {});
+
+      // This mustRead call is expected to fail with EntityNotFoundException because the ledger
+      // is empty. We are only executing mustRead here to force the call to key generation
+      // (which calls createCompositeKey internally) so that we can verify the key type name.
+      assertThrows(
+          EntityNotFoundException.class, () -> registry.mustRead(AnnotatedEntity.class, "id-1"));
+
+      // Verify that the annotated entity type ("Asset") was indeed used for creating the composite
+      // key
+      then(stub).should().createCompositeKey(eq("Asset"), any(String[].class));
       verifyNoMoreInteractions(stub);
     }
 


### PR DESCRIPTION
### Description

This PR ensures stable and predictable entity type generation, especially for composite keys.

### Changes

- Removed locale-dependent uppercasing from Registry entity type derivation.
- Introduced @EntityType annotation for explicitly defining stable object type names.
- Added deterministic fallback using class FQCN when annotation is not present.
- Added tests covering:
- Annotated entity type resolution
- Default class-name fallback behavior
- Updated README with usage examples for @EntityType.

fixes #66 