### PR TITLE
fix(middleware): ensure blind deletes are persisted in dispose()

### DIFF
--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/WriteBackCachedStubMiddleware.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/WriteBackCachedStubMiddleware.java
@@ -117,10 +117,13 @@ public final class WriteBackCachedStubMiddleware extends StubMiddleware {
     for (final Map.Entry<String, CachedItem> entry : cache.entrySet()) {
       final CachedItem item = entry.getValue();
 
-      if (item == null || !item.isDirty() || item.getValue() == null) continue;
+      if (item == null || !item.isDirty()) continue;
 
-      if (item.isToDelete()) this.nextStub.delState(item.getKey());
-      else this.nextStub.putState(item.getKey(), item.getValue());
+      if (item.isToDelete()) {
+        this.nextStub.delState(item.getKey());
+      } else if (item.getValue() != null) {
+        this.nextStub.putState(item.getKey(), item.getValue());
+      }
     }
   }
 

--- a/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/middleware/WriteBackCachedStubMiddlewareTest.java
+++ b/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/middleware/WriteBackCachedStubMiddlewareTest.java
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.middleware;
+
+import static org.mockito.Mockito.*;
+
+import org.hyperledger.fabric.shim.ChaincodeStub;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class WriteBackCachedStubMiddlewareTest {
+
+  @Mock ChaincodeStub fabricStub;
+
+  WriteBackCachedStubMiddleware middleware;
+
+  @BeforeEach
+  void setUp() {
+    middleware = new WriteBackCachedStubMiddleware();
+    middleware.nextStub = fabricStub;
+  }
+
+  @Test
+  void blind_delete_is_flushed_to_underlying_stub_on_dispose() {
+    middleware.delState("key-never-read");
+
+    middleware.dispose();
+
+    verify(fabricStub).delState("key-never-read");
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #63

Calling `delState()` on a key that was never read in the current transaction (a 'blind delete') was silently dropped during `dispose()`. The cache entry had `value=null` and `toDelete=true`, but the condition `item.getValue() == null` in `dispose()` caused it to be skipped entirely.

## Changes

**`WriteBackCachedStubMiddleware.dispose()`** - Restructured the loop to check `isToDelete()` independently of the cached value:

Before (buggy):
```
if (item == null || !item.isDirty() || item.getValue() == null) continue;
```

After (fixed):
```
if (item == null || !item.isDirty()) continue;
if (item.isToDelete()) {
    this.nextStub.delState(item.getKey());
} else if (item.getValue() != null) {
    this.nextStub.putState(item.getKey(), item.getValue());
}
```

**Regression test** - Added `WriteBackCachedStubMiddlewareTest` with a test verifying blind deletes are flushed to the underlying stub on `dispose()`.

## Testing
```
./gradlew build test  # 29 tests, BUILD SUCCESSFUL
```