### PR TITLE
fix: flush blind deletes in WriteBackCachedStubMiddleware#dispose()

### DIFF
--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/WriteBackCachedStubMiddleware.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/WriteBackCachedStubMiddleware.java
@@ -117,10 +117,13 @@ public final class WriteBackCachedStubMiddleware extends StubMiddleware {
     for (final Map.Entry<String, CachedItem> entry : cache.entrySet()) {
       final CachedItem item = entry.getValue();
 
-      if (item == null || !item.isDirty() || item.getValue() == null) continue;
+      if (item == null || !item.isDirty()) continue;
 
-      if (item.isToDelete()) this.nextStub.delState(item.getKey());
-      else this.nextStub.putState(item.getKey(), item.getValue());
+      if (item.isToDelete()) {
+        this.nextStub.delState(item.getKey());
+      } else if (item.getValue() != null) {
+        this.nextStub.putState(item.getKey(), item.getValue());
+      }
     }
   }
 


### PR DESCRIPTION
Resolves #90.

This PR fixes a bug in the [WriteBackCachedStubMiddleware](cci:2://file:///c:/Users/aftab/Desktop/hypernate/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/WriteBackCachedStubMiddleware.java:18:0-158:1) where deletions of keys that hadn't been manually populated in the cache yet (blind deletes) were getting silently dropped during transaction flushes.

## What was happening
When calling [delState](cci:1://file:///c:/Users/aftab/Desktop/hypernate/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/WriteBackCachedStubMiddleware.java:85:2-107:3) on an uncached key, the middleware blindly instantiated a new [CachedItem](cci:2://file:///c:/Users/aftab/Desktop/hypernate/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/WriteBackCachedStubMiddleware.java:129:2-160:3) with a `null` value. Later, the [dispose()](cci:1://file:///c:/Users/aftab/Desktop/hypernate/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/WriteBackCachedStubMiddleware.java:109:2-124:3) loop had a guard statement `if (... || item.getValue() == null) continue;`. This incorrectly bounced the deletion just because its state value was `null`, meaning the `nextStub.delState()` call never executed and the ledger remained unchanged.

## The Fix
I've decoupled the `item.getValue() == null` check from the deletion branch in [dispose()](cci:1://file:///c:/Users/aftab/Desktop/hypernate/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/WriteBackCachedStubMiddleware.java:109:2-124:3). As a result, the null check now strictly guards [putState](cci:1://file:///c:/Users/aftab/Desktop/hypernate/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/WriteBackCachedStubMiddleware.java:53:2-83:3) writes, and all deletions safely flush down to the underlying `ChaincodeStub` as expected.

I also ran `spotlessApply` so all formatting is in check. 

Let me know if there's anything else you'd like adjusted!
