### PR TITLE
Expand LoggingStubMiddleware coverage with safe redaction

### DIFF
--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/contract/HypernateContract.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/contract/HypernateContract.java
@@ -2,11 +2,15 @@
 package hu.bme.mit.ftsrg.hypernate.contract;
 
 import hu.bme.mit.ftsrg.hypernate.context.HypernateContext;
+import hu.bme.mit.ftsrg.hypernate.middleware.LoggingConfig;
+import hu.bme.mit.ftsrg.hypernate.middleware.LoggingStubMiddleware;
 import hu.bme.mit.ftsrg.hypernate.middleware.MiddlewareInfo;
 import hu.bme.mit.ftsrg.hypernate.middleware.StubMiddleware;
 import hu.bme.mit.ftsrg.hypernate.middleware.StubMiddlewareChain;
 import hu.bme.mit.ftsrg.hypernate.middleware.notification.TransactionBegin;
 import hu.bme.mit.ftsrg.hypernate.middleware.notification.TransactionEnd;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 import org.hyperledger.fabric.contract.Context;
 import org.hyperledger.fabric.contract.ContractInterface;
@@ -59,10 +63,33 @@ public interface HypernateContract extends ContractInterface {
       return StubMiddlewareChain.emptyChain(fabricStub);
     }
 
+    LoggingConfig loggingConfig = getClass().getAnnotation(LoggingConfig.class);
     Class<? extends StubMiddleware>[] middlewareClasses = mwInfoAnnot.value();
     StubMiddlewareChain.Builder builder = StubMiddlewareChain.builder(fabricStub);
-    Arrays.stream(middlewareClasses).forEach(builder::push);
+    Arrays.stream(middlewareClasses)
+        .map(middlewareClass -> instantiateMiddleware(middlewareClass, loggingConfig))
+        .forEach(builder::push);
 
     return builder.build();
+  }
+
+  private StubMiddleware instantiateMiddleware(
+      final Class<? extends StubMiddleware> middlewareClass, final LoggingConfig loggingConfig) {
+    if (middlewareClass == LoggingStubMiddleware.class && loggingConfig != null) {
+      return LoggingStubMiddleware.fromAnnotation(loggingConfig);
+    }
+
+    Constructor<? extends StubMiddleware> constructor;
+    try {
+      constructor = middlewareClass.getDeclaredConstructor();
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException("Could not find no-arg constructor for " + middlewareClass, e);
+    }
+
+    try {
+      return constructor.newInstance();
+    } catch (InvocationTargetException | InstantiationException | IllegalAccessException e) {
+      throw new RuntimeException("Failed to instantiate " + middlewareClass, e);
+    }
   }
 }

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/CollectionLogConfig.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/CollectionLogConfig.java
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.middleware;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Per-collection logging configuration for {@link LoggingStubMiddleware}. */
+@Target({})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CollectionLogConfig {
+  /** Collection name. Use an empty string for public state. */
+  String name();
+
+  /** How key-like inputs should be logged for this collection. */
+  KeyLogMode keyMode();
+
+  /** How values should be logged for this collection. */
+  ValueLogMode valueMode();
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/KeyLogMode.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/KeyLogMode.java
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.middleware;
+
+/** Controls how key-like inputs are represented in middleware logs. */
+public enum KeyLogMode {
+  /** Log only the operation name and non-key metadata. */
+  OPERATION_ONLY,
+  /** Log the UTF-8 byte length and a SHA-256 hash of the key material. */
+  KEY_HASH,
+  /** Log composite key shape only, or the length of non-composite key material. */
+  KEY_PREFIX,
+  /** Log the full key or query input. */
+  FULL_KEY
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/LogConfig.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/LogConfig.java
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.middleware;
+
+import java.util.Objects;
+
+/** Runtime logging configuration for a public state space or private collection. */
+public record LogConfig(KeyLogMode keyMode, ValueLogMode valueMode) {
+
+  public LogConfig {
+    Objects.requireNonNull(keyMode, "keyMode cannot be null");
+    Objects.requireNonNull(valueMode, "valueMode cannot be null");
+  }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/LoggingConfig.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/LoggingConfig.java
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.middleware;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Contract-level logging configuration for {@link LoggingStubMiddleware}. */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoggingConfig {
+  /** Default key log mode for public state and any collection without an override. */
+  KeyLogMode defaultKeyMode() default KeyLogMode.KEY_PREFIX;
+
+  /** Default value log mode for public state and any collection without an override. */
+  ValueLogMode defaultValueMode() default ValueLogMode.KEYS_ONLY;
+
+  /** Optional per-collection overrides. */
+  CollectionLogConfig[] collections() default {};
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/LoggingStubMiddleware.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/LoggingStubMiddleware.java
@@ -1,23 +1,56 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 package hu.bme.mit.ftsrg.hypernate.middleware;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.hyperledger.fabric.shim.Chaincode.Response;
 import org.hyperledger.fabric.shim.ChaincodeStub;
+import org.hyperledger.fabric.shim.ledger.CompositeKey;
+import org.hyperledger.fabric.shim.ledger.KeyModification;
+import org.hyperledger.fabric.shim.ledger.KeyValue;
+import org.hyperledger.fabric.shim.ledger.QueryResultsIterator;
+import org.hyperledger.fabric.shim.ledger.QueryResultsIteratorWithMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 /**
- * Stub middleware that simply logs all {@link ChaincodeStub#getState(String)}, {@link
- * ChaincodeStub#putState(String, byte[])}, and {@link ChaincodeStub#delState(String)} calls.
+ * Stub middleware that logs ledger-facing {@link ChaincodeStub} operations using configurable key
+ * and value redaction.
  *
  * @see StubMiddleware
  */
 public class LoggingStubMiddleware extends StubMiddleware {
 
+  private static final String PUBLIC_STATE_COLLECTION = "";
+
+  private static final int TRUNCATED_VALUE_CHAR_LIMIT = 256;
+
+  private static final HexFormat HEX_FORMAT = HexFormat.of();
+
+  private static final LogConfig DEFAULT_PUBLIC_LOG_CONFIG =
+      new LogConfig(KeyLogMode.KEY_PREFIX, ValueLogMode.KEYS_ONLY);
+
+  private static final LogConfig DEFAULT_PRIVATE_LOG_CONFIG =
+      new LogConfig(KeyLogMode.KEY_HASH, ValueLogMode.KEYS_ONLY);
+
   private final Logger logger;
 
   private final Level logLevel;
+
+  private final LogConfig publicDefaultConfig;
+
+  private final LogConfig privateDefaultConfig;
+
+  private final Map<String, LogConfig> collectionConfigs;
 
   public LoggingStubMiddleware() {
     this(LoggerFactory.getLogger(LoggingStubMiddleware.class));
@@ -28,51 +61,586 @@ public class LoggingStubMiddleware extends StubMiddleware {
   }
 
   public LoggingStubMiddleware(final Logger logger, final Level logLevel) {
-    this.logger = logger;
-    this.logLevel = logLevel;
+    this(logger, logLevel, DEFAULT_PUBLIC_LOG_CONFIG, DEFAULT_PRIVATE_LOG_CONFIG, Map.of());
   }
 
-  /**
-   * Get the raw state at {@code key} but log a message before and after doing so.
-   *
-   * @param key the queried key
-   * @return the raw state at {@code key}
-   */
+  public LoggingStubMiddleware(
+      final Logger logger,
+      final Level logLevel,
+      final LogConfig defaultConfig,
+      final Map<String, LogConfig> collectionConfigs) {
+    this(logger, logLevel, defaultConfig, defaultConfig, collectionConfigs);
+  }
+
+  public static LoggingStubMiddleware fromAnnotation(final LoggingConfig loggingConfig) {
+    return fromAnnotation(
+        LoggerFactory.getLogger(LoggingStubMiddleware.class), Level.DEBUG, loggingConfig);
+  }
+
+  static LoggingStubMiddleware fromAnnotation(
+      final Logger logger, final Level logLevel, final LoggingConfig loggingConfig) {
+    LogConfig defaultConfig =
+        new LogConfig(loggingConfig.defaultKeyMode(), loggingConfig.defaultValueMode());
+    Map<String, LogConfig> collectionConfigs =
+        Arrays.stream(loggingConfig.collections())
+            .collect(
+                Collectors.toUnmodifiableMap(
+                    CollectionLogConfig::name,
+                    config -> new LogConfig(config.keyMode(), config.valueMode())));
+    return new LoggingStubMiddleware(
+        logger, logLevel, defaultConfig, defaultConfig, collectionConfigs);
+  }
+
+  private LoggingStubMiddleware(
+      final Logger logger,
+      final Level logLevel,
+      final LogConfig publicDefaultConfig,
+      final LogConfig privateDefaultConfig,
+      final Map<String, LogConfig> collectionConfigs) {
+    this.logger = Objects.requireNonNull(logger, "logger cannot be null");
+    this.logLevel = Objects.requireNonNull(logLevel, "logLevel cannot be null");
+    this.publicDefaultConfig =
+        Objects.requireNonNull(publicDefaultConfig, "publicDefaultConfig cannot be null");
+    this.privateDefaultConfig =
+        Objects.requireNonNull(privateDefaultConfig, "privateDefaultConfig cannot be null");
+    this.collectionConfigs = collectionConfigs == null ? Map.of() : Map.copyOf(collectionConfigs);
+  }
+
   @Override
   public byte[] getState(final String key) {
-    log("Getting state for key '{}'", key);
-    final byte[] value = this.nextStub.getState(key);
-    log("Got state for key '{}'; value = '{}'", key, Arrays.toString(value));
+    LogConfig config = getPublicConfig();
+    String keyDetail = formatKeyDetail("key", key, config.keyMode());
+    logOperation("getState", keyDetail);
+    byte[] value = this.nextStub.getState(key);
+    logOperation(
+        "getState result", keyDetail, formatBinaryValueDetail("value", value, config.valueMode()));
     return value;
   }
 
-  /**
-   * Write raw state passed in {@code value} at {@code key} but log a message before and after doing
-   * so.
-   *
-   * @param key where to write {@code value}
-   * @param value what to write at {@code key}
-   */
+  @Override
+  public String getStringState(final String key) {
+    LogConfig config = getPublicConfig();
+    String keyDetail = formatKeyDetail("key", key, config.keyMode());
+    logOperation("getStringState", keyDetail);
+    String value = this.nextStub.getStringState(key);
+    logOperation(
+        "getStringState result",
+        keyDetail,
+        formatTextValueDetail("value", value, config.valueMode()));
+    return value;
+  }
+
   @Override
   public void putState(final String key, final byte[] value) {
-    log("Setting state for key '{}' to have value '{}'", key, Arrays.toString(value));
+    LogConfig config = getPublicConfig();
+    String keyDetail = formatKeyDetail("key", key, config.keyMode());
+    logOperation(
+        "putState", keyDetail, formatBinaryValueDetail("value", value, config.valueMode()));
     this.nextStub.putState(key, value);
-    log("Done setting state for key '{}'", key);
+    logOperation("putState complete", keyDetail);
   }
 
-  /**
-   * Delete the value at {@code key} but log a message before and after doing so.
-   *
-   * @param key the key whose value should be deleted
-   */
+  @Override
+  public void putStringState(final String key, final String value) {
+    LogConfig config = getPublicConfig();
+    String keyDetail = formatKeyDetail("key", key, config.keyMode());
+    logOperation(
+        "putStringState", keyDetail, formatTextValueDetail("value", value, config.valueMode()));
+    this.nextStub.putStringState(key, value);
+    logOperation("putStringState complete", keyDetail);
+  }
+
+  @Override
+  public void setStateValidationParameter(final String key, final byte[] value) {
+    LogConfig config = getPublicConfig();
+    String keyDetail = formatKeyDetail("key", key, config.keyMode());
+    logOperation("setStateValidationParameter", keyDetail);
+    this.nextStub.setStateValidationParameter(key, value);
+    logOperation("setStateValidationParameter complete", keyDetail);
+  }
+
   @Override
   public void delState(final String key) {
-    log("Deleting state for key '{}'", key);
+    LogConfig config = getPublicConfig();
+    String keyDetail = formatKeyDetail("key", key, config.keyMode());
+    logOperation("delState", keyDetail);
     this.nextStub.delState(key);
-    log("Done deleting state for key '{}'", key);
+    logOperation("delState complete", keyDetail);
   }
 
-  private void log(final String format, Object... args) {
-    logger.atLevel(logLevel).log(format, args);
+  @Override
+  public QueryResultsIterator<KeyValue> getStateByRange(
+      final String startKey, final String endKey) {
+    LogConfig config = getPublicConfig();
+    logOperation(
+        "getStateByRange",
+        formatKeyDetail("startKey", startKey, config.keyMode()),
+        formatKeyDetail("endKey", endKey, config.keyMode()));
+    return this.nextStub.getStateByRange(startKey, endKey);
+  }
+
+  @Override
+  public QueryResultsIteratorWithMetadata<KeyValue> getStateByRangeWithPagination(
+      final String startKey, final String endKey, final int pageSize, final String bookmark) {
+    LogConfig config = getPublicConfig();
+    logOperation(
+        "getStateByRangeWithPagination",
+        formatKeyDetail("startKey", startKey, config.keyMode()),
+        formatKeyDetail("endKey", endKey, config.keyMode()),
+        "pageSize=" + pageSize,
+        formatOpaqueTextDetail("bookmark", bookmark, config.keyMode()));
+    return this.nextStub.getStateByRangeWithPagination(startKey, endKey, pageSize, bookmark);
+  }
+
+  @Override
+  public QueryResultsIterator<KeyValue> getStateByPartialCompositeKey(final String compositeKey) {
+    LogConfig config = getPublicConfig();
+    logOperation(
+        "getStateByPartialCompositeKey",
+        formatCompositeKeyStringDetail("compositeKey", compositeKey, config.keyMode()));
+    return this.nextStub.getStateByPartialCompositeKey(compositeKey);
+  }
+
+  @Override
+  public QueryResultsIterator<KeyValue> getStateByPartialCompositeKey(
+      final String objectType, final String... attributes) {
+    LogConfig config = getPublicConfig();
+    logOperation(
+        "getStateByPartialCompositeKey",
+        formatCompositeKeyPartsDetail("compositeKey", objectType, attributes, config.keyMode()));
+    return this.nextStub.getStateByPartialCompositeKey(objectType, attributes);
+  }
+
+  @Override
+  public QueryResultsIterator<KeyValue> getStateByPartialCompositeKey(
+      final CompositeKey compositeKey) {
+    LogConfig config = getPublicConfig();
+    logOperation(
+        "getStateByPartialCompositeKey",
+        formatCompositeKeyDetail("compositeKey", compositeKey, config.keyMode()));
+    return this.nextStub.getStateByPartialCompositeKey(compositeKey);
+  }
+
+  @Override
+  public QueryResultsIteratorWithMetadata<KeyValue> getStateByPartialCompositeKeyWithPagination(
+      final CompositeKey compositeKey, final int pageSize, final String bookmark) {
+    LogConfig config = getPublicConfig();
+    logOperation(
+        "getStateByPartialCompositeKeyWithPagination",
+        formatCompositeKeyDetail("compositeKey", compositeKey, config.keyMode()),
+        "pageSize=" + pageSize,
+        formatOpaqueTextDetail("bookmark", bookmark, config.keyMode()));
+    return this.nextStub.getStateByPartialCompositeKeyWithPagination(
+        compositeKey, pageSize, bookmark);
+  }
+
+  @Override
+  public QueryResultsIterator<KeyValue> getQueryResult(final String query) {
+    LogConfig config = getPublicConfig();
+    logOperation("getQueryResult", formatOpaqueTextDetail("query", query, config.keyMode()));
+    return this.nextStub.getQueryResult(query);
+  }
+
+  @Override
+  public QueryResultsIteratorWithMetadata<KeyValue> getQueryResultWithPagination(
+      final String query, final int pageSize, final String bookmark) {
+    LogConfig config = getPublicConfig();
+    logOperation(
+        "getQueryResultWithPagination",
+        formatOpaqueTextDetail("query", query, config.keyMode()),
+        "pageSize=" + pageSize,
+        formatOpaqueTextDetail("bookmark", bookmark, config.keyMode()));
+    return this.nextStub.getQueryResultWithPagination(query, pageSize, bookmark);
+  }
+
+  @Override
+  public QueryResultsIterator<KeyModification> getHistoryForKey(final String key) {
+    LogConfig config = getPublicConfig();
+    logOperation("getHistoryForKey", formatKeyDetail("key", key, config.keyMode()));
+    return this.nextStub.getHistoryForKey(key);
+  }
+
+  @Override
+  public byte[] getPrivateData(final String collection, final String key) {
+    LogConfig config = getCollectionConfig(collection);
+    String collectionDetail = formatCollectionDetail(collection);
+    String keyDetail = formatKeyDetail("key", key, config.keyMode());
+    logOperation("getPrivateData", collectionDetail, keyDetail);
+    byte[] value = this.nextStub.getPrivateData(collection, key);
+    logOperation(
+        "getPrivateData result",
+        collectionDetail,
+        keyDetail,
+        formatBinaryValueDetail("value", value, config.valueMode()));
+    return value;
+  }
+
+  @Override
+  public void putPrivateData(final String collection, final String key, final byte[] value) {
+    LogConfig config = getCollectionConfig(collection);
+    String collectionDetail = formatCollectionDetail(collection);
+    String keyDetail = formatKeyDetail("key", key, config.keyMode());
+    logOperation(
+        "putPrivateData",
+        collectionDetail,
+        keyDetail,
+        formatBinaryValueDetail("value", value, config.valueMode()));
+    this.nextStub.putPrivateData(collection, key, value);
+    logOperation("putPrivateData complete", collectionDetail, keyDetail);
+  }
+
+  @Override
+  public void putPrivateData(final String collection, final String key, final String value) {
+    LogConfig config = getCollectionConfig(collection);
+    String collectionDetail = formatCollectionDetail(collection);
+    String keyDetail = formatKeyDetail("key", key, config.keyMode());
+    logOperation(
+        "putPrivateData",
+        collectionDetail,
+        keyDetail,
+        formatTextValueDetail("value", value, config.valueMode()));
+    this.nextStub.putPrivateData(collection, key, value);
+    logOperation("putPrivateData complete", collectionDetail, keyDetail);
+  }
+
+  @Override
+  public void setPrivateDataValidationParameter(
+      final String collection, final String key, final byte[] value) {
+    LogConfig config = getCollectionConfig(collection);
+    String collectionDetail = formatCollectionDetail(collection);
+    String keyDetail = formatKeyDetail("key", key, config.keyMode());
+    logOperation("setPrivateDataValidationParameter", collectionDetail, keyDetail);
+    this.nextStub.setPrivateDataValidationParameter(collection, key, value);
+    logOperation("setPrivateDataValidationParameter complete", collectionDetail, keyDetail);
+  }
+
+  @Override
+  public void delPrivateData(final String collection, final String key) {
+    LogConfig config = getCollectionConfig(collection);
+    String collectionDetail = formatCollectionDetail(collection);
+    String keyDetail = formatKeyDetail("key", key, config.keyMode());
+    logOperation("delPrivateData", collectionDetail, keyDetail);
+    this.nextStub.delPrivateData(collection, key);
+    logOperation("delPrivateData complete", collectionDetail, keyDetail);
+  }
+
+  @Override
+  public void purgePrivateData(final String collection, final String key) {
+    LogConfig config = getCollectionConfig(collection);
+    String collectionDetail = formatCollectionDetail(collection);
+    String keyDetail = formatKeyDetail("key", key, config.keyMode());
+    logOperation("purgePrivateData", collectionDetail, keyDetail);
+    this.nextStub.purgePrivateData(collection, key);
+    logOperation("purgePrivateData complete", collectionDetail, keyDetail);
+  }
+
+  @Override
+  public byte[] getPrivateDataHash(final String collection, final String key) {
+    LogConfig config = getCollectionConfig(collection);
+    String collectionDetail = formatCollectionDetail(collection);
+    String keyDetail = formatKeyDetail("key", key, config.keyMode());
+    logOperation("getPrivateDataHash", collectionDetail, keyDetail);
+    byte[] value = this.nextStub.getPrivateDataHash(collection, key);
+    logOperation(
+        "getPrivateDataHash result",
+        collectionDetail,
+        keyDetail,
+        formatBinaryValueDetail("hash", value, config.valueMode()));
+    return value;
+  }
+
+  @Override
+  public byte[] getPrivateDataValidationParameter(final String collection, final String key) {
+    LogConfig config = getCollectionConfig(collection);
+    String collectionDetail = formatCollectionDetail(collection);
+    String keyDetail = formatKeyDetail("key", key, config.keyMode());
+    logOperation("getPrivateDataValidationParameter", collectionDetail, keyDetail);
+    byte[] value = this.nextStub.getPrivateDataValidationParameter(collection, key);
+    logOperation(
+        "getPrivateDataValidationParameter result",
+        collectionDetail,
+        keyDetail,
+        formatBinaryValueDetail("endorsementPolicy", value, config.valueMode()));
+    return value;
+  }
+
+  @Override
+  public QueryResultsIterator<KeyValue> getPrivateDataByRange(
+      final String collection, final String startKey, final String endKey) {
+    LogConfig config = getCollectionConfig(collection);
+    logOperation(
+        "getPrivateDataByRange",
+        formatCollectionDetail(collection),
+        formatKeyDetail("startKey", startKey, config.keyMode()),
+        formatKeyDetail("endKey", endKey, config.keyMode()));
+    return this.nextStub.getPrivateDataByRange(collection, startKey, endKey);
+  }
+
+  @Override
+  public QueryResultsIterator<KeyValue> getPrivateDataByPartialCompositeKey(
+      final String collection, final String compositeKey) {
+    LogConfig config = getCollectionConfig(collection);
+    logOperation(
+        "getPrivateDataByPartialCompositeKey",
+        formatCollectionDetail(collection),
+        formatCompositeKeyStringDetail("compositeKey", compositeKey, config.keyMode()));
+    return this.nextStub.getPrivateDataByPartialCompositeKey(collection, compositeKey);
+  }
+
+  @Override
+  public QueryResultsIterator<KeyValue> getPrivateDataByPartialCompositeKey(
+      final String collection, final CompositeKey compositeKey) {
+    LogConfig config = getCollectionConfig(collection);
+    logOperation(
+        "getPrivateDataByPartialCompositeKey",
+        formatCollectionDetail(collection),
+        formatCompositeKeyDetail("compositeKey", compositeKey, config.keyMode()));
+    return this.nextStub.getPrivateDataByPartialCompositeKey(collection, compositeKey);
+  }
+
+  @Override
+  public QueryResultsIterator<KeyValue> getPrivateDataByPartialCompositeKey(
+      final String collection, final String objectType, final String... attributes) {
+    LogConfig config = getCollectionConfig(collection);
+    logOperation(
+        "getPrivateDataByPartialCompositeKey",
+        formatCollectionDetail(collection),
+        formatCompositeKeyPartsDetail("compositeKey", objectType, attributes, config.keyMode()));
+    return this.nextStub.getPrivateDataByPartialCompositeKey(collection, objectType, attributes);
+  }
+
+  @Override
+  public QueryResultsIterator<KeyValue> getPrivateDataQueryResult(
+      final String collection, final String query) {
+    LogConfig config = getCollectionConfig(collection);
+    logOperation(
+        "getPrivateDataQueryResult",
+        formatCollectionDetail(collection),
+        formatOpaqueTextDetail("query", query, config.keyMode()));
+    return this.nextStub.getPrivateDataQueryResult(collection, query);
+  }
+
+  @Override
+  public Response invokeChaincode(
+      final String chaincodeName, final List<byte[]> args, final String channel) {
+    logOperation(
+        "invokeChaincode",
+        "chaincode='" + chaincodeName + "'",
+        "channel='" + (channel == null || channel.isBlank() ? "<current>" : channel) + "'");
+    Response response = this.nextStub.invokeChaincode(chaincodeName, args, channel);
+    logOperation("invokeChaincode complete", "chaincode='" + chaincodeName + "'");
+    return response;
+  }
+
+  @Override
+  public void setEvent(final String name, final byte[] payload) {
+    logOperation(
+        "setEvent",
+        "name='" + name + "'",
+        "payloadBytes=" + (payload == null ? 0 : payload.length));
+    this.nextStub.setEvent(name, payload);
+    logOperation("setEvent complete", "name='" + name + "'");
+  }
+
+  private LogConfig getPublicConfig() {
+    return collectionConfigs.getOrDefault(PUBLIC_STATE_COLLECTION, publicDefaultConfig);
+  }
+
+  private LogConfig getCollectionConfig(final String collection) {
+    return collectionConfigs.getOrDefault(collection, privateDefaultConfig);
+  }
+
+  private void logOperation(final String operation, final String... details) {
+    String detailText =
+        Arrays.stream(details)
+            .filter(Objects::nonNull)
+            .filter(detail -> !detail.isBlank())
+            .collect(Collectors.joining(", "));
+    if (detailText.isBlank()) {
+      log(operation);
+    } else {
+      log(operation + ": " + detailText);
+    }
+  }
+
+  private String formatCollectionDetail(final String collection) {
+    return "collection='" + collection + "'";
+  }
+
+  private String formatKeyDetail(final String label, final String key, final KeyLogMode mode) {
+    return switch (mode) {
+      case OPERATION_ONLY -> null;
+      case KEY_HASH -> formatHashedTextDetail(label, key);
+      case KEY_PREFIX -> formatPrefixDetail(label, key);
+      case FULL_KEY -> label + "='" + key + "'";
+    };
+  }
+
+  private String formatOpaqueTextDetail(
+      final String label, final String text, final KeyLogMode mode) {
+    return switch (mode) {
+      case OPERATION_ONLY -> null;
+      case KEY_HASH -> formatHashedTextDetail(label, text);
+      case KEY_PREFIX -> label + "{length=" + utf8Length(text) + "}";
+      case FULL_KEY -> label + "='" + text + "'";
+    };
+  }
+
+  private String formatCompositeKeyStringDetail(
+      final String label, final String compositeKey, final KeyLogMode mode) {
+    if (compositeKey != null && compositeKey.startsWith(CompositeKey.NAMESPACE)) {
+      try {
+        return formatCompositeKeyDetail(label, CompositeKey.parseCompositeKey(compositeKey), mode);
+      } catch (RuntimeException ignored) {
+        // Fall back to raw string handling below.
+      }
+    }
+    return formatKeyDetail(label, compositeKey, mode);
+  }
+
+  private String formatCompositeKeyDetail(
+      final String label, final CompositeKey compositeKey, final KeyLogMode mode) {
+    if (mode == KeyLogMode.OPERATION_ONLY) {
+      return null;
+    }
+
+    List<String> attributes = compositeKey == null ? List.of() : compositeKey.getAttributes();
+    String objectType = compositeKey == null ? null : compositeKey.getObjectType();
+    return switch (mode) {
+      case KEY_HASH -> formatHashedTextDetail(
+          label, compositeKey == null ? null : compositeKey.toString());
+      case KEY_PREFIX -> label
+          + "{objectType='"
+          + objectType
+          + "', attributeCount="
+          + attributes.size()
+          + "}";
+      case FULL_KEY -> label + "{objectType='" + objectType + "', attributes=" + attributes + "}";
+      case OPERATION_ONLY -> null;
+    };
+  }
+
+  private String formatCompositeKeyPartsDetail(
+      final String label,
+      final String objectType,
+      final String[] attributes,
+      final KeyLogMode mode) {
+    if (mode == KeyLogMode.OPERATION_ONLY) {
+      return null;
+    }
+
+    String[] nonNullAttributes = attributes == null ? new String[0] : attributes;
+    return switch (mode) {
+      case KEY_HASH -> formatHashedTextDetail(
+          label, new CompositeKey(objectType, nonNullAttributes).toString());
+      case KEY_PREFIX -> label
+          + "{objectType='"
+          + objectType
+          + "', attributeCount="
+          + nonNullAttributes.length
+          + "}";
+      case FULL_KEY -> label
+          + "{objectType='"
+          + objectType
+          + "', attributes="
+          + Arrays.toString(nonNullAttributes)
+          + "}";
+      case OPERATION_ONLY -> null;
+    };
+  }
+
+  private String formatPrefixDetail(final String label, final String key) {
+    if (key != null && key.startsWith(CompositeKey.NAMESPACE)) {
+      try {
+        CompositeKey compositeKey = CompositeKey.parseCompositeKey(key);
+        return label
+            + "{objectType='"
+            + compositeKey.getObjectType()
+            + "', attributeCount="
+            + compositeKey.getAttributes().size()
+            + "}";
+      } catch (RuntimeException ignored) {
+        // Fall back to opaque handling below.
+      }
+    }
+    return label + "{kind=simple,length=" + utf8Length(key) + "}";
+  }
+
+  private String formatHashedTextDetail(final String label, final String text) {
+    return label
+        + "{bytes="
+        + utf8Length(text)
+        + ",sha256='"
+        + sha256Hex(text == null ? null : text.getBytes(UTF_8))
+        + "'}";
+  }
+
+  private String formatBinaryValueDetail(
+      final String label, final byte[] value, final ValueLogMode mode) {
+    return switch (mode) {
+      case KEYS_ONLY -> null;
+      case VALUE_METADATA -> label
+          + "{bytes="
+          + byteLength(value)
+          + ",sha256='"
+          + sha256Hex(value)
+          + "'}";
+      case VALUE_UTF8 -> label + "='" + decodeUtf8(value) + "'";
+      case VALUE_UTF8_TRUNCATED -> label + "='" + truncate(decodeUtf8(value)) + "'";
+    };
+  }
+
+  private String formatTextValueDetail(
+      final String label, final String value, final ValueLogMode mode) {
+    return switch (mode) {
+      case KEYS_ONLY -> null;
+      case VALUE_METADATA -> label
+          + "{bytes="
+          + utf8Length(value)
+          + ",sha256='"
+          + sha256Hex(value == null ? null : value.getBytes(UTF_8))
+          + "'}";
+      case VALUE_UTF8 -> label + "='" + value + "'";
+      case VALUE_UTF8_TRUNCATED -> label + "='" + truncate(value) + "'";
+    };
+  }
+
+  private String decodeUtf8(final byte[] value) {
+    return value == null ? null : new String(value, UTF_8);
+  }
+
+  private int utf8Length(final String text) {
+    return text == null ? 0 : text.getBytes(UTF_8).length;
+  }
+
+  private int byteLength(final byte[] value) {
+    return value == null ? 0 : value.length;
+  }
+
+  private String truncate(final String value) {
+    if (value == null || value.length() <= TRUNCATED_VALUE_CHAR_LIMIT) {
+      return value;
+    }
+    return value.substring(0, TRUNCATED_VALUE_CHAR_LIMIT)
+        + "...(truncated,chars="
+        + value.length()
+        + ")";
+  }
+
+  private String sha256Hex(final byte[] value) {
+    if (value == null) {
+      return "null";
+    }
+
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      return HEX_FORMAT.formatHex(digest.digest(value));
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 is not available", e);
+    }
+  }
+
+  private void log(final String message) {
+    logger.atLevel(logLevel).log(message);
   }
 }

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/ValueLogMode.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/ValueLogMode.java
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.middleware;
+
+/** Controls how values are represented in middleware logs. */
+public enum ValueLogMode {
+  /** Do not log value contents or metadata. */
+  KEYS_ONLY,
+  /** Log only byte length and a SHA-256 hash. */
+  VALUE_METADATA,
+  /** Interpret bytes as UTF-8 and log the full text. */
+  VALUE_UTF8,
+  /** Interpret bytes as UTF-8 and log only a fixed-size prefix. */
+  VALUE_UTF8_TRUNCATED
+}

--- a/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/middleware/LoggingStubMiddlewareTest.java
+++ b/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/middleware/LoggingStubMiddlewareTest.java
@@ -1,0 +1,271 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.middleware;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import hu.bme.mit.ftsrg.hypernate.contract.HypernateContract;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import org.hyperledger.fabric.shim.Chaincode.Response;
+import org.hyperledger.fabric.shim.ChaincodeStub;
+import org.hyperledger.fabric.shim.ledger.CompositeKey;
+import org.hyperledger.fabric.shim.ledger.KeyModification;
+import org.hyperledger.fabric.shim.ledger.KeyValue;
+import org.hyperledger.fabric.shim.ledger.QueryResultsIterator;
+import org.hyperledger.fabric.shim.ledger.QueryResultsIteratorWithMetadata;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+import org.slf4j.spi.LoggingEventBuilder;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class LoggingStubMiddlewareTest {
+
+  @Mock ChaincodeStub fabricStub;
+  @Mock Logger logger;
+  @Mock LoggingEventBuilder loggingEventBuilder;
+
+  LoggingStubMiddleware middleware;
+
+  @BeforeEach
+  void setUp() {
+    lenient().when(logger.atLevel(any(Level.class))).thenReturn(loggingEventBuilder);
+    middleware =
+        new LoggingStubMiddleware(
+            logger,
+            Level.DEBUG,
+            new LogConfig(KeyLogMode.FULL_KEY, ValueLogMode.VALUE_UTF8),
+            Map.of());
+    middleware.nextStub = fabricStub;
+  }
+
+  @Test
+  void getState_delegates_to_next_stub_correctly() {
+    byte[] expected = "value".getBytes(StandardCharsets.UTF_8);
+    when(fabricStub.getState("key1")).thenReturn(expected);
+
+    byte[] result = middleware.getState("key1");
+
+    assertArrayEquals(expected, result);
+    verify(fabricStub).getState("key1");
+  }
+
+  @Test
+  void putState_delegates_to_next_stub_correctly() {
+    byte[] value = "value".getBytes(StandardCharsets.UTF_8);
+
+    middleware.putState("key1", value);
+
+    verify(fabricStub).putState("key1", value);
+  }
+
+  @Test
+  void delState_delegates_to_next_stub_correctly() {
+    middleware.delState("key1");
+
+    verify(fabricStub).delState("key1");
+  }
+
+  @Test
+  void configured_public_logging_can_include_full_keys_and_utf8_values() {
+    byte[] value = "super-secret".getBytes(StandardCharsets.UTF_8);
+    when(fabricStub.getState("asset-123")).thenReturn(value);
+
+    middleware.getState("asset-123");
+
+    verify(loggingEventBuilder).log("getState: key='asset-123'");
+    verify(loggingEventBuilder).log("getState result: key='asset-123', value='super-secret'");
+  }
+
+  @Test
+  void default_configuration_keeps_public_values_out_of_logs() {
+    LoggingStubMiddleware safeDefaults = new LoggingStubMiddleware(logger, Level.DEBUG);
+    safeDefaults.nextStub = fabricStub;
+    when(fabricStub.getState("asset-123"))
+        .thenReturn("top-secret".getBytes(StandardCharsets.UTF_8));
+
+    safeDefaults.getState("asset-123");
+
+    verify(loggingEventBuilder).log("getState: key{kind=simple,length=9}");
+    verify(loggingEventBuilder).log("getState result: key{kind=simple,length=9}");
+    verify(loggingEventBuilder, never()).log(contains("top-secret"));
+    verify(loggingEventBuilder, never()).log(contains("asset-123"));
+  }
+
+  @Test
+  void default_configuration_hashes_private_keys_and_hides_private_values() {
+    LoggingStubMiddleware safeDefaults = new LoggingStubMiddleware(logger, Level.DEBUG);
+    safeDefaults.nextStub = fabricStub;
+    when(fabricStub.getPrivateData("privateMedical", "patient-john-doe"))
+        .thenReturn("diagnosis".getBytes(StandardCharsets.UTF_8));
+
+    safeDefaults.getPrivateData("privateMedical", "patient-john-doe");
+
+    verify(loggingEventBuilder)
+        .log(startsWith("getPrivateData: collection='privateMedical', key{bytes=16,sha256='"));
+    verify(loggingEventBuilder)
+        .log(
+            startsWith(
+                "getPrivateData result: collection='privateMedical', key{bytes=16,sha256='"));
+    verify(loggingEventBuilder, never()).log(contains("patient-john-doe"));
+    verify(loggingEventBuilder, never()).log(contains("diagnosis"));
+  }
+
+  @Test
+  void collection_overrides_apply_to_private_data_logging() {
+    LoggingStubMiddleware configured =
+        new LoggingStubMiddleware(
+            logger,
+            Level.DEBUG,
+            new LogConfig(KeyLogMode.FULL_KEY, ValueLogMode.VALUE_UTF8),
+            Map.of(
+                "privateMedical", new LogConfig(KeyLogMode.KEY_HASH, ValueLogMode.VALUE_METADATA)));
+    configured.nextStub = fabricStub;
+    when(fabricStub.getPrivateData("privateMedical", "patient-john-doe"))
+        .thenReturn("diagnosis".getBytes(StandardCharsets.UTF_8));
+
+    configured.getPrivateData("privateMedical", "patient-john-doe");
+
+    verify(loggingEventBuilder)
+        .log(startsWith("getPrivateData: collection='privateMedical', key{bytes=16,sha256='"));
+    verify(loggingEventBuilder)
+        .log(
+            startsWith(
+                "getPrivateData result: collection='privateMedical', key{bytes=16,sha256='"));
+    verify(loggingEventBuilder, never()).log(contains("patient-john-doe"));
+    verify(loggingEventBuilder, never()).log(contains("diagnosis"));
+  }
+
+  @Test
+  void annotation_configuration_is_applied_when_contract_builds_middlewares() throws Exception {
+    LoggingStubMiddleware configured =
+        (LoggingStubMiddleware) new ConfiguredContract().initMiddlewares(fabricStub).getFirst();
+
+    assertEquals(
+        new LogConfig(KeyLogMode.FULL_KEY, ValueLogMode.VALUE_UTF8),
+        getField(configured, "publicDefaultConfig"));
+    assertEquals(
+        new LogConfig(KeyLogMode.FULL_KEY, ValueLogMode.VALUE_UTF8),
+        getField(configured, "privateDefaultConfig"));
+    @SuppressWarnings("unchecked")
+    Map<String, LogConfig> collectionConfigs =
+        (Map<String, LogConfig>) getField(configured, "collectionConfigs");
+    assertEquals(
+        new LogConfig(KeyLogMode.KEY_HASH, ValueLogMode.VALUE_METADATA),
+        collectionConfigs.get("privateMedical"));
+  }
+
+  @Test
+  void relevant_stub_methods_are_overridden_locally_and_not_left_to_delegate() throws Exception {
+    assertOverridden("getState", String.class);
+    assertOverridden("getStringState", String.class);
+    assertOverridden("putState", String.class, byte[].class);
+    assertOverridden("putStringState", String.class, String.class);
+    assertOverridden("setStateValidationParameter", String.class, byte[].class);
+    assertOverridden("delState", String.class);
+    assertOverridden("getStateByRange", String.class, String.class);
+    assertOverridden(
+        "getStateByRangeWithPagination", String.class, String.class, int.class, String.class);
+    assertOverridden("getStateByPartialCompositeKey", String.class);
+    assertOverridden("getStateByPartialCompositeKey", String.class, String[].class);
+    assertOverridden("getStateByPartialCompositeKey", CompositeKey.class);
+    assertOverridden(
+        "getStateByPartialCompositeKeyWithPagination", CompositeKey.class, int.class, String.class);
+    assertOverridden("getQueryResult", String.class);
+    assertOverridden("getQueryResultWithPagination", String.class, int.class, String.class);
+    assertOverridden("getHistoryForKey", String.class);
+    assertOverridden("getPrivateData", String.class, String.class);
+    assertOverridden("putPrivateData", String.class, String.class, byte[].class);
+    assertOverridden("putPrivateData", String.class, String.class, String.class);
+    assertOverridden("setPrivateDataValidationParameter", String.class, String.class, byte[].class);
+    assertOverridden("delPrivateData", String.class, String.class);
+    assertOverridden("purgePrivateData", String.class, String.class);
+    assertOverridden("getPrivateDataHash", String.class, String.class);
+    assertOverridden("getPrivateDataValidationParameter", String.class, String.class);
+    assertOverridden("getPrivateDataByRange", String.class, String.class, String.class);
+    assertOverridden("getPrivateDataByPartialCompositeKey", String.class, String.class);
+    assertOverridden("getPrivateDataByPartialCompositeKey", String.class, CompositeKey.class);
+    assertOverridden(
+        "getPrivateDataByPartialCompositeKey", String.class, String.class, String[].class);
+    assertOverridden("getPrivateDataQueryResult", String.class, String.class);
+    assertOverridden("invokeChaincode", String.class, List.class, String.class);
+    assertOverridden("setEvent", String.class, byte[].class);
+  }
+
+  @Test
+  void representative_query_and_event_calls_still_delegate() {
+    @SuppressWarnings("unchecked")
+    QueryResultsIterator<KeyValue> stateIterator = mock(QueryResultsIterator.class);
+    @SuppressWarnings("unchecked")
+    QueryResultsIterator<KeyModification> historyIterator = mock(QueryResultsIterator.class);
+    @SuppressWarnings("unchecked")
+    QueryResultsIteratorWithMetadata<KeyValue> pagedIterator =
+        mock(QueryResultsIteratorWithMetadata.class);
+    Response response = new Response(200, "ok", "done".getBytes(StandardCharsets.UTF_8));
+
+    when(fabricStub.getStateByRange("a", "z")).thenReturn(stateIterator);
+    when(fabricStub.getHistoryForKey("asset-123")).thenReturn(historyIterator);
+    when(fabricStub.getQueryResultWithPagination("{}", 10, "bookmark")).thenReturn(pagedIterator);
+    when(fabricStub.invokeChaincode("othercc", List.of(), null)).thenReturn(response);
+
+    assertSame(stateIterator, middleware.getStateByRange("a", "z"));
+    assertSame(historyIterator, middleware.getHistoryForKey("asset-123"));
+    assertSame(pagedIterator, middleware.getQueryResultWithPagination("{}", 10, "bookmark"));
+    assertSame(response, middleware.invokeChaincode("othercc", List.of(), null));
+    middleware.setEvent("eventName", "payload".getBytes(StandardCharsets.UTF_8));
+
+    verify(fabricStub).getStateByRange("a", "z");
+    verify(fabricStub).getHistoryForKey("asset-123");
+    verify(fabricStub).getQueryResultWithPagination("{}", 10, "bookmark");
+    verify(fabricStub).invokeChaincode("othercc", List.of(), null);
+    verify(fabricStub).setEvent("eventName", "payload".getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void no_calls_are_silently_swallowed_for_core_state_methods() {
+    byte[] value = "data".getBytes(StandardCharsets.UTF_8);
+    when(fabricStub.getState("k")).thenReturn(value);
+
+    middleware.getState("k");
+    middleware.putState("k", value);
+    middleware.delState("k");
+
+    verify(fabricStub).getState("k");
+    verify(fabricStub).putState("k", value);
+    verify(fabricStub).delState("k");
+    verifyNoMoreInteractions(fabricStub);
+  }
+
+  private void assertOverridden(final String methodName, final Class<?>... parameterTypes)
+      throws Exception {
+    Method method = LoggingStubMiddleware.class.getMethod(methodName, parameterTypes);
+    assertEquals(LoggingStubMiddleware.class, method.getDeclaringClass(), methodName);
+  }
+
+  private Object getField(final Object target, final String fieldName) throws Exception {
+    Field field = LoggingStubMiddleware.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return field.get(target);
+  }
+
+  @MiddlewareInfo({LoggingStubMiddleware.class})
+  @LoggingConfig(
+      defaultKeyMode = KeyLogMode.FULL_KEY,
+      defaultValueMode = ValueLogMode.VALUE_UTF8,
+      collections = {
+        @CollectionLogConfig(
+            name = "privateMedical",
+            keyMode = KeyLogMode.KEY_HASH,
+            valueMode = ValueLogMode.VALUE_METADATA)
+      })
+  private static class ConfiguredContract implements HypernateContract {}
+}


### PR DESCRIPTION
## Summary

This implements the approved design in #34 for `LoggingStubMiddleware`.

### Method coverage

Expands logging beyond `getState`, `putState`, and `delState` to cover the requested ledger-facing `ChaincodeStub` operations:

- Public state operations: string state helpers and state validation parameter writes
- Range, composite key, rich query, paginated query, and history lookups
- Private data operations including reads, writes, deletes, purge, hashes, validation parameters, range queries, composite key queries, and rich queries
- Cross-chaincode invocation through the core `invokeChaincode(String, List<byte[]>, String)` method
- Chaincode events via `setEvent`

The methods explicitly listed as “skip” in #34 are left untouched.

### Redaction and configuration

Adds configurable logging modes so the middleware does not leak raw keys or values by default:

- `KeyLogMode`
  - `OPERATION_ONLY`
  - `KEY_HASH`
  - `KEY_PREFIX`
  - `FULL_KEY`
- `ValueLogMode`
  - `KEYS_ONLY`
  - `VALUE_METADATA`
  - `VALUE_UTF8`
  - `VALUE_UTF8_TRUNCATED`

Safe defaults are applied when no configuration is provided:

- Public state: `KEY_PREFIX` + `KEYS_ONLY`
- Private collections: `KEY_HASH` + `KEYS_ONLY`

Adds `LogConfig`, `@LoggingConfig`, and `@CollectionLogConfig` so projects can configure defaults and per-collection overrides either programmatically or through contract annotations.

### Contract integration

Updates `HypernateContract` middleware initialization so `@LoggingConfig` is detected and used when constructing `LoggingStubMiddleware`.

## Test plan

- `./gradlew.bat :lib:spotlessCheck :lib:test`

Closes #34 
