### PR TITLE
feat(registry): entity CRUD for Fabric private data collections

### DIFF
--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/EntityStateStore.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/EntityStateStore.java
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.registry;
+
+import org.hyperledger.fabric.shim.ledger.KeyValue;
+import org.hyperledger.fabric.shim.ledger.QueryResultsIterator;
+
+interface EntityStateStore {
+
+  byte[] get(String key);
+
+  void put(String key, byte[] value);
+
+  void delete(String key);
+
+  QueryResultsIterator<KeyValue> getByPartialCompositeKey(String key);
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/PrivateDataRegistry.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/PrivateDataRegistry.java
@@ -8,4 +8,11 @@ public final class PrivateDataRegistry extends Registry {
   PrivateDataRegistry(final ChaincodeStub stub, final String collection) {
     super(stub, new PrivateDataStateStore(stub, collection));
   }
+
+  @Override
+  public PrivateDataRegistry privateData(final String collection) {
+    throw new UnsupportedOperationException(
+        "Cannot rebind a PrivateDataRegistry to a different collection. "
+            + "Use ctx.getRegistry().privateData(\"" + collection + "\") instead.");
+  }
 }

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/PrivateDataRegistry.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/PrivateDataRegistry.java
@@ -13,6 +13,8 @@ public final class PrivateDataRegistry extends Registry {
   public PrivateDataRegistry privateData(final String collection) {
     throw new UnsupportedOperationException(
         "Cannot rebind a PrivateDataRegistry to a different collection. "
-            + "Use ctx.getRegistry().privateData(\"" + collection + "\") instead.");
+            + "Use ctx.getRegistry().privateData(\""
+            + collection
+            + "\") instead.");
   }
 }

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/PrivateDataRegistry.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/PrivateDataRegistry.java
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.registry;
+
+import org.hyperledger.fabric.shim.ChaincodeStub;
+
+public final class PrivateDataRegistry extends Registry {
+
+  PrivateDataRegistry(final ChaincodeStub stub, final String collection) {
+    super(stub, new PrivateDataStateStore(stub, collection));
+  }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/PrivateDataStateStore.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/PrivateDataStateStore.java
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.registry;
+
+import org.hyperledger.fabric.shim.ChaincodeStub;
+import org.hyperledger.fabric.shim.ledger.KeyValue;
+import org.hyperledger.fabric.shim.ledger.QueryResultsIterator;
+
+final class PrivateDataStateStore implements EntityStateStore {
+
+  private final ChaincodeStub stub;
+  private final String collection;
+
+  PrivateDataStateStore(final ChaincodeStub stub, final String collection) {
+    this.stub = stub;
+    this.collection = collection;
+  }
+
+  @Override
+  public byte[] get(final String key) {
+    return stub.getPrivateData(collection, key);
+  }
+
+  @Override
+  public void put(final String key, final byte[] value) {
+    stub.putPrivateData(collection, key, value);
+  }
+
+  @Override
+  public void delete(final String key) {
+    stub.delPrivateData(collection, key);
+  }
+
+  @Override
+  public QueryResultsIterator<KeyValue> getByPartialCompositeKey(final String key) {
+    return stub.getPrivateDataByPartialCompositeKey(collection, key);
+  }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/PublicStateStore.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/PublicStateStore.java
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.registry;
+
+import org.hyperledger.fabric.shim.ChaincodeStub;
+import org.hyperledger.fabric.shim.ledger.KeyValue;
+import org.hyperledger.fabric.shim.ledger.QueryResultsIterator;
+
+final class PublicStateStore implements EntityStateStore {
+
+  private final ChaincodeStub stub;
+
+  PublicStateStore(final ChaincodeStub stub) {
+    this.stub = stub;
+  }
+
+  @Override
+  public byte[] get(final String key) {
+    return stub.getState(key);
+  }
+
+  @Override
+  public void put(final String key, final byte[] value) {
+    stub.putState(key, value);
+  }
+
+  @Override
+  public void delete(final String key) {
+    stub.delState(key);
+  }
+
+  @Override
+  public QueryResultsIterator<KeyValue> getByPartialCompositeKey(final String key) {
+    return stub.getStateByPartialCompositeKey(key);
+  }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java
@@ -26,9 +26,23 @@ public class Registry {
   private static final Logger logger = LoggerFactory.getLogger(Registry.class);
 
   private final ChaincodeStub stub;
+  private final EntityStateStore store;
 
   public Registry(final ChaincodeStub stub) {
+    this(stub, new PublicStateStore(stub));
+  }
+
+  Registry(final ChaincodeStub stub, final EntityStateStore store) {
     this.stub = stub;
+    this.store = store;
+  }
+
+  public PrivateDataRegistry privateData(final String collection) {
+    if (collection == null || collection.isBlank()) {
+      throw new IllegalArgumentException("Private data collection name must not be blank");
+    }
+
+    return new PrivateDataRegistry(stub, collection);
   }
 
   /**
@@ -43,7 +57,7 @@ public class Registry {
 
     final String key = getCompositeKey(entity);
     final byte[] buffer = EntityUtil.toBuffer(entity);
-    stub.putState(key, buffer);
+    store.put(key, buffer);
   }
 
   /**
@@ -76,7 +90,7 @@ public class Registry {
 
     final String key = getCompositeKey(entity);
     final byte[] buffer = EntityUtil.toBuffer(entity);
-    stub.putState(key, buffer);
+    store.put(key, buffer);
   }
 
   /**
@@ -108,7 +122,7 @@ public class Registry {
     assertExists(entity);
 
     final String key = getCompositeKey(entity);
-    stub.delState(key);
+    store.delete(key);
   }
 
   /**
@@ -155,7 +169,7 @@ public class Registry {
         stub.createCompositeKey(
                 EntityUtil.getType(clazz), EntityUtil.mapKeyPartsToString(clazz, keyParts))
             .toString();
-    final byte[] data = stub.getState(key);
+    final byte[] data = store.get(key);
 
     if (data == null || data.length == 0) {
       throw new EntityNotFoundException(key);
@@ -190,7 +204,7 @@ public class Registry {
    */
   public <T> List<T> readAll(final Class<T> clazz) {
     final String key = stub.createCompositeKey(EntityUtil.getType(clazz)).toString();
-    Iterator<KeyValue> iterator = stub.getStateByPartialCompositeKey(key).iterator();
+    Iterator<KeyValue> iterator = store.getByPartialCompositeKey(key).iterator();
     Iterable<KeyValue> iterable = () -> iterator;
     return StreamSupport.stream(iterable.spliterator(), false)
         .map(
@@ -208,7 +222,7 @@ public class Registry {
 
   @Loggable(Loggable.DEBUG)
   private boolean keyExists(final String key) {
-    final byte[] valueOnLedger = stub.getState(key);
+    final byte[] valueOnLedger = store.get(key);
     return valueOnLedger != null && valueOnLedger.length > 0;
   }
 

--- a/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/RegistryTest.java
+++ b/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/RegistryTest.java
@@ -361,8 +361,7 @@ class RegistryTest {
     }
 
     @Test
-    void given_empty_ledger_with_complete_key_then_throw_not_found()
-        throws SerializationException {
+    void given_empty_ledger_with_complete_key_then_throw_not_found() throws SerializationException {
       given(stub.createCompositeKey(anyString(), any(String[].class)))
           .willReturn(ENTITY_COMPOSITE_KEY);
       given(stub.getState(anyString())).willReturn(new byte[] {});
@@ -454,8 +453,7 @@ class RegistryTest {
     void given_private_registry_then_privateData_throws_unsupported() {
       PrivateDataRegistry privateRegistry = registry.privateData(COLLECTION);
 
-      assertThrows(
-          UnsupportedOperationException.class, () -> privateRegistry.privateData("other"));
+      assertThrows(UnsupportedOperationException.class, () -> privateRegistry.privateData("other"));
       verifyNoMoreInteractions(stub);
     }
 

--- a/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/RegistryTest.java
+++ b/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/RegistryTest.java
@@ -12,6 +12,7 @@ import hu.bme.mit.ftsrg.hypernate.annotations.PrimaryKey;
 import hu.bme.mit.ftsrg.hypernate.registry.EntityExistsException;
 import hu.bme.mit.ftsrg.hypernate.registry.EntityNotFoundException;
 import hu.bme.mit.ftsrg.hypernate.registry.MissingPrimaryKeysException;
+import hu.bme.mit.ftsrg.hypernate.registry.PrivateDataRegistry;
 import hu.bme.mit.ftsrg.hypernate.registry.Registry;
 import hu.bme.mit.ftsrg.hypernate.registry.SerializationException;
 import hu.bme.mit.ftsrg.hypernate.util.JSON;
@@ -40,6 +41,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class RegistryTest {
 
   private static final TestEntity entity = new TestEntity("fooValue", 110);
+  private static final String COLLECTION = "assetPrivateCollection";
 
   private static final CompositeKey ENTITY_COMPOSITE_KEY =
       new CompositeKey(entity.getClass().getName(), entity.foo, entity.bar.toString());
@@ -431,6 +433,195 @@ class RegistryTest {
 
       then(stub).should().getState(ENTITY_COMPOSITE_KEY_STR);
       assertEquals(entity, result);
+      verifyNoMoreInteractions(stub);
+    }
+  }
+
+  @Nested
+  class when_using_private_data_registry {
+
+    @Test
+    void given_blank_collection_name_then_throw_illegal_argument() {
+      assertThrows(IllegalArgumentException.class, () -> registry.privateData(null));
+      assertThrows(IllegalArgumentException.class, () -> registry.privateData(""));
+      assertThrows(IllegalArgumentException.class, () -> registry.privateData("   "));
+      verifyNoMoreInteractions(stub);
+    }
+
+    @Test
+    void given_empty_private_data_then_must_create_calls_putPrivateData()
+        throws EntityExistsException {
+      given(stub.createCompositeKey(anyString(), any(String[].class)))
+          .willReturn(ENTITY_COMPOSITE_KEY);
+      given(stub.getPrivateData(COLLECTION, ENTITY_COMPOSITE_KEY_STR)).willReturn(new byte[] {});
+
+      PrivateDataRegistry privateRegistry = registry.privateData(COLLECTION);
+      privateRegistry.mustCreate(entity);
+
+      then(stub)
+          .should()
+          .putPrivateData(eq(COLLECTION), eq(ENTITY_COMPOSITE_KEY_STR), any(byte[].class));
+      verifyNoMoreInteractions(stub);
+    }
+
+    @Test
+    void given_existing_private_data_then_must_create_throws_exists() {
+      given(stub.createCompositeKey(anyString(), any(String[].class)))
+          .willReturn(ENTITY_COMPOSITE_KEY);
+      given(stub.getPrivateData(COLLECTION, ENTITY_COMPOSITE_KEY_STR)).willReturn(ENTITY_BUFFER);
+
+      PrivateDataRegistry privateRegistry = registry.privateData(COLLECTION);
+
+      assertThrows(EntityExistsException.class, () -> privateRegistry.mustCreate(entity));
+      verifyNoMoreInteractions(stub);
+    }
+
+    @Test
+    void given_existing_private_data_then_must_read_returns_entity()
+        throws EntityNotFoundException {
+      given(stub.createCompositeKey(anyString(), any(String[].class)))
+          .willReturn(ENTITY_COMPOSITE_KEY);
+      given(stub.getPrivateData(COLLECTION, ENTITY_COMPOSITE_KEY_STR)).willReturn(ENTITY_BUFFER);
+
+      PrivateDataRegistry privateRegistry = registry.privateData(COLLECTION);
+      TestEntity result = privateRegistry.mustRead(TestEntity.class, entity.foo, entity.bar);
+
+      then(stub).should().getPrivateData(COLLECTION, ENTITY_COMPOSITE_KEY_STR);
+      assertEquals(entity, result);
+      verifyNoMoreInteractions(stub);
+    }
+
+    @Test
+    void given_empty_private_data_then_must_read_throws_not_found() {
+      given(stub.createCompositeKey(anyString(), any(String[].class)))
+          .willReturn(ENTITY_COMPOSITE_KEY);
+      given(stub.getPrivateData(COLLECTION, ENTITY_COMPOSITE_KEY_STR)).willReturn(new byte[] {});
+
+      PrivateDataRegistry privateRegistry = registry.privateData(COLLECTION);
+
+      assertThrows(
+          EntityNotFoundException.class,
+          () -> privateRegistry.mustRead(TestEntity.class, entity.foo, entity.bar));
+      verifyNoMoreInteractions(stub);
+    }
+
+    @Test
+    void given_existing_private_data_then_must_update_calls_putPrivateData()
+        throws EntityNotFoundException {
+      given(stub.createCompositeKey(anyString(), any(String[].class)))
+          .willReturn(ENTITY_COMPOSITE_KEY);
+      given(stub.getPrivateData(COLLECTION, ENTITY_COMPOSITE_KEY_STR)).willReturn(ENTITY_BUFFER);
+
+      PrivateDataRegistry privateRegistry = registry.privateData(COLLECTION);
+      privateRegistry.mustUpdate(entity);
+
+      then(stub)
+          .should()
+          .putPrivateData(eq(COLLECTION), eq(ENTITY_COMPOSITE_KEY_STR), any(byte[].class));
+      verifyNoMoreInteractions(stub);
+    }
+
+    @Test
+    void given_existing_private_data_then_must_delete_calls_delPrivateData()
+        throws EntityNotFoundException {
+      given(stub.createCompositeKey(anyString(), any(String[].class)))
+          .willReturn(ENTITY_COMPOSITE_KEY);
+      given(stub.getPrivateData(COLLECTION, ENTITY_COMPOSITE_KEY_STR)).willReturn(ENTITY_BUFFER);
+
+      PrivateDataRegistry privateRegistry = registry.privateData(COLLECTION);
+      privateRegistry.mustDelete(entity);
+
+      then(stub).should().delPrivateData(COLLECTION, ENTITY_COMPOSITE_KEY_STR);
+      verifyNoMoreInteractions(stub);
+    }
+
+    @Test
+    void given_empty_private_data_collection_then_readAll_returns_empty_list() {
+      given(stub.createCompositeKey(anyString())).willReturn(ENTITY_COMPOSITE_KEY);
+      given(stub.getPrivateDataByPartialCompositeKey(eq(COLLECTION), anyString()))
+          .willReturn(
+              new QueryResultsIterator<>() {
+                @Override
+                public void close() {}
+
+                @Override
+                public @Nonnull Iterator<KeyValue> iterator() {
+                  return new Iterator<>() {
+                    @Override
+                    public boolean hasNext() {
+                      return false;
+                    }
+
+                    @Override
+                    public KeyValue next() {
+                      throw new UnsupportedOperationException();
+                    }
+                  };
+                }
+              });
+
+      PrivateDataRegistry privateRegistry = registry.privateData(COLLECTION);
+      List<TestEntity> results = privateRegistry.readAll(TestEntity.class);
+
+      then(stub).should().getPrivateDataByPartialCompositeKey(eq(COLLECTION), anyString());
+      assertTrue(results.isEmpty());
+      verifyNoMoreInteractions(stub);
+    }
+
+    @Test
+    void given_existing_private_data_collection_then_readAll_returns_entities() {
+      given(stub.createCompositeKey(anyString())).willReturn(ENTITY_COMPOSITE_KEY);
+      given(stub.getPrivateDataByPartialCompositeKey(eq(COLLECTION), anyString()))
+          .willReturn(
+              new QueryResultsIterator<>() {
+                private boolean done = false;
+
+                @Override
+                public void close() {}
+
+                @Override
+                public @Nonnull Iterator<KeyValue> iterator() {
+                  return new Iterator<>() {
+                    @Override
+                    public boolean hasNext() {
+                      return !done;
+                    }
+
+                    @Override
+                    public KeyValue next() {
+                      if (done) {
+                        throw new UnsupportedOperationException();
+                      }
+
+                      done = true;
+
+                      return new KeyValue() {
+                        @Override
+                        public String getKey() {
+                          return ENTITY_COMPOSITE_KEY_STR;
+                        }
+
+                        @Override
+                        public byte[] getValue() {
+                          return ENTITY_BUFFER;
+                        }
+
+                        @Override
+                        public String getStringValue() {
+                          return Arrays.toString(getValue());
+                        }
+                      };
+                    }
+                  };
+                }
+              });
+
+      PrivateDataRegistry privateRegistry = registry.privateData(COLLECTION);
+      List<TestEntity> results = privateRegistry.readAll(TestEntity.class);
+
+      then(stub).should().getPrivateDataByPartialCompositeKey(eq(COLLECTION), anyString());
+      assertEquals(1, results.size());
+      assertEquals(entity, results.get(0));
       verifyNoMoreInteractions(stub);
     }
   }

--- a/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/RegistryTest.java
+++ b/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/RegistryTest.java
@@ -259,10 +259,10 @@ class RegistryTest {
   }
 
   @Nested
-  class when_readAll {
+  class when_read_all {
 
     @Test
-    void given_empty_ledger_then_return_empty_list() throws SerializationException {
+    void given_empty_ledger_then_return_empty_list() {
       given(stub.createCompositeKey(anyString())).willReturn(ENTITY_COMPOSITE_KEY);
       given(stub.getStateByPartialCompositeKey(anyString()))
           .willReturn(
@@ -294,7 +294,7 @@ class RegistryTest {
     }
 
     @Test
-    void given_existing_entity_then_return_one_long_list() throws SerializationException {
+    void given_existing_entity_then_return_list_with_entity() throws SerializationException {
       given(stub.createCompositeKey(anyString())).willReturn(ENTITY_COMPOSITE_KEY);
       given(stub.getStateByPartialCompositeKey(anyString()))
           .willReturn(
@@ -345,6 +345,7 @@ class RegistryTest {
 
       then(stub).should().getStateByPartialCompositeKey(anyString());
       assertEquals(1, results.size());
+      assertEquals(entity, results.get(0));
       verifyNoMoreInteractions(stub);
     }
   }
@@ -360,7 +361,8 @@ class RegistryTest {
     }
 
     @Test
-    void given_empty_ledger_with_complete_key_then_throw_not_found() {
+    void given_empty_ledger_with_complete_key_then_throw_not_found()
+        throws SerializationException {
       given(stub.createCompositeKey(anyString(), any(String[].class)))
           .willReturn(ENTITY_COMPOSITE_KEY);
       given(stub.getState(anyString())).willReturn(new byte[] {});
@@ -445,6 +447,15 @@ class RegistryTest {
       assertThrows(IllegalArgumentException.class, () -> registry.privateData(null));
       assertThrows(IllegalArgumentException.class, () -> registry.privateData(""));
       assertThrows(IllegalArgumentException.class, () -> registry.privateData("   "));
+      verifyNoMoreInteractions(stub);
+    }
+
+    @Test
+    void given_private_registry_then_privateData_throws_unsupported() {
+      PrivateDataRegistry privateRegistry = registry.privateData(COLLECTION);
+
+      assertThrows(
+          UnsupportedOperationException.class, () -> privateRegistry.privateData("other"));
       verifyNoMoreInteractions(stub);
     }
 


### PR DESCRIPTION
Closes LF-Decentralized-Trust-labs/hypernate#106

## Summary

This PR adds first-class support for storing Hypernate entities in Fabric private data collections. Developers can now persist entities in private collections through the same [Registry](cci:2://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:22:0-378:1) API used for public world state, without dropping down to raw `ChaincodeStub` calls or duplicating composite key, serialization, and existence-check logic.

The new entry point is [registry.privateData("collectionName")](cci:1://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:39:2-45:3), which returns a [PrivateDataRegistry](cci:2://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/PrivateDataRegistry.java:5:0-10:1) exposing the same CRUD surface as the public [Registry](cci:2://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:22:0-378:1): [mustCreate](cci:1://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:47:2-60:3), [tryCreate](cci:1://file:///c:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:62:2-78:3), [mustRead](cci:1://file:///c:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:145:2-178:3), [tryRead](cci:1://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:180:2-195:3), [mustUpdate](cci:1://file:///c:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:80:2-93:3), [tryUpdate](cci:1://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:95:2-111:3), [mustDelete](cci:1://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:113:2-125:3), [tryDelete](cci:1://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:127:2-143:3), and [readAll](cci:1://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:197:2-220:3).

Public [Registry](cci:2://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:22:0-378:1) behavior is unchanged. `ctx.getRegistry().mustCreate(entity)` still writes to public world state exactly as before.

## Architecture

The internal storage path of [Registry](cci:2://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:22:0-378:1) was decoupled from `ChaincodeStub` through a small package-private abstraction:

```
Registry ──► EntityStateStore ──► ChaincodeStub
                  ▲
                  │ implements
        ┌─────────┴─────────┐
        │                   │
PublicStateStore    PrivateDataStateStore
(world state)       (collection-scoped)
```

- [Registry](cci:2://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:22:0-378:1) no longer talks to `ChaincodeStub` for state I/O. It goes through an [EntityStateStore](cci:2://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/EntityStateStore.java:6:0-15:1) ([get](cci:1://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/EntityStateStore.java:8:2-8:25) / [put](cci:1://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/EntityStateStore.java:10:2-10:37) / [delete](cci:1://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/EntityStateStore.java:12:2-12:26) / [getByPartialCompositeKey](cci:1://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/EntityStateStore.java:14:2-14:70)).
- [PublicStateStore](cci:2://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/PublicStateStore.java:7:0-34:1) routes those operations to the existing world-state methods (`getState` / `putState` / `delState` / `getStateByPartialCompositeKey`). This is the default backend, used when constructing [Registry](cci:2://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:22:0-378:1) from a `ChaincodeStub` directly, so existing call sites and middleware behavior are preserved.
- [PrivateDataStateStore](cci:2://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/PrivateDataStateStore.java:7:0-36:1) routes them to the collection-scoped methods (`getPrivateData` / `putPrivateData` / `delPrivateData` / `getPrivateDataByPartialCompositeKey`), capturing the collection name as state.
- [PrivateDataRegistry](cci:2://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/PrivateDataRegistry.java:5:0-10:1) is a thin [Registry](cci:2://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:22:0-378:1) subclass bound to a [PrivateDataStateStore](cci:2://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/PrivateDataStateStore.java:7:0-36:1). All CRUD logic, key generation, JSON serialization, and exception semantics are inherited unchanged.
- [Registry.privateData(String collection)](cci:1://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:39:2-45:3) is the public entry point and validates that the collection name is non-null and non-blank.
- Composite-key construction still uses `ChaincodeStub.createCompositeKey`, so public and private entities share the exact same key format.
- Middleware integration is unaffected: [HypernateContext](cci:2://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/context/HypernateContext.java:20:0-53:1) still builds [Registry](cci:2://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:22:0-378:1) with [middlewareChain.getFirst()](cci:1://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/StubMiddlewareChain.java:49:2-63:3), and [PrivateDataRegistry](cci:2://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/PrivateDataRegistry.java:5:0-10:1) reuses that same effective stub.


## Compatibility

- Public [Registry](cci:2://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:22:0-378:1) signatures, exceptions, and storage behavior are unchanged. Existing tests still pass.
- The change is fully additive at the public API surface. No deprecations.
- Private CRUD calls pass through the existing middleware chain.

## Tests

New tests in [RegistryTest.when_using_private_data_registry](cci:2://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/RegistryTest.java:439:2-622:3) cover CRUD, [readAll](cci:1://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:197:2-220:3), and collection-name validation. Existing public [Registry](cci:2://file:///C:/Users/troll/.windsurf/worktrees/hypernate/hypernate-a5871373/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java:22:0-378:1) tests still assert `putState` / `getState` / `delState` behavior. `./gradlew build` runs `spotlessCheck`, compile, and the full test suite: **BUILD SUCCESSFUL**, 53 tests passed.

## Follow-ups

Open questions from issue #106 that this PR intentionally does not address:

- `@PrivateDataOnly` annotation to prevent accidental storage of sensitive entities in public world state.
- `getPrivateDataHash` support for transactions running in organizations without access to the collection.