### PR TITLE
WIP: Hypernate Fabric Query Engine (MVP)

### DIFF
--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/annotations/EndorsementPolicy.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/annotations/EndorsementPolicy.java
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface EndorsementPolicy {
+  String value();
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/context/CrossChaincodeDeserializationException.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/context/CrossChaincodeDeserializationException.java
@@ -9,9 +9,13 @@ public class CrossChaincodeDeserializationException extends RuntimeException {
   private final String functionName;
   private final Class<?> expectedType;
 
-  public CrossChaincodeDeserializationException(String chaincodeId, String functionName, Class<?> expectedType, Throwable cause) {
-    super(String.format("Failed to deserialize response from %s#%s into %s: %s", 
-        chaincodeId, functionName, expectedType.getSimpleName(), cause.getMessage()), cause);
+  public CrossChaincodeDeserializationException(
+      String chaincodeId, String functionName, Class<?> expectedType, Throwable cause) {
+    super(
+        String.format(
+            "Failed to deserialize response from %s#%s into %s: %s",
+            chaincodeId, functionName, expectedType.getSimpleName(), cause.getMessage()),
+        cause);
     this.chaincodeId = chaincodeId;
     this.functionName = functionName;
     this.expectedType = expectedType;

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/context/CrossChaincodeDeserializationException.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/context/CrossChaincodeDeserializationException.java
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.context;
+
+import lombok.Getter;
+
+@Getter
+public class CrossChaincodeDeserializationException extends RuntimeException {
+  private final String chaincodeId;
+  private final String functionName;
+  private final Class<?> expectedType;
+
+  public CrossChaincodeDeserializationException(String chaincodeId, String functionName, Class<?> expectedType, Throwable cause) {
+    super(String.format("Failed to deserialize response from %s#%s into %s: %s", 
+        chaincodeId, functionName, expectedType.getSimpleName(), cause.getMessage()), cause);
+    this.chaincodeId = chaincodeId;
+    this.functionName = functionName;
+    this.expectedType = expectedType;
+  }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/context/CrossChaincodeException.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/context/CrossChaincodeException.java
@@ -10,9 +10,12 @@ public class CrossChaincodeException extends RuntimeException {
   private final int statusCode;
   private final String originalMessage;
 
-  public CrossChaincodeException(String chaincodeId, String functionName, int statusCode, String originalMessage) {
-    super(String.format("Cross-chaincode call to %s#%s failed with status %d: %s", 
-        chaincodeId, functionName, statusCode, originalMessage));
+  public CrossChaincodeException(
+      String chaincodeId, String functionName, int statusCode, String originalMessage) {
+    super(
+        String.format(
+            "Cross-chaincode call to %s#%s failed with status %d: %s",
+            chaincodeId, functionName, statusCode, originalMessage));
     this.chaincodeId = chaincodeId;
     this.functionName = functionName;
     this.statusCode = statusCode;

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/context/CrossChaincodeException.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/context/CrossChaincodeException.java
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.context;
+
+import lombok.Getter;
+
+@Getter
+public class CrossChaincodeException extends RuntimeException {
+  private final String chaincodeId;
+  private final String functionName;
+  private final int statusCode;
+  private final String originalMessage;
+
+  public CrossChaincodeException(String chaincodeId, String functionName, int statusCode, String originalMessage) {
+    super(String.format("Cross-chaincode call to %s#%s failed with status %d: %s", 
+        chaincodeId, functionName, statusCode, originalMessage));
+    this.chaincodeId = chaincodeId;
+    this.functionName = functionName;
+    this.statusCode = statusCode;
+    this.originalMessage = originalMessage;
+  }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/context/HypernateContext.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/context/HypernateContext.java
@@ -38,6 +38,17 @@ public class HypernateContext extends Context {
   }
 
   /**
+   * Start a cross-chaincode invocation builder.
+   *
+   * @param chaincodeName the target chaincode name
+   * @param functionName the target function name
+   * @return an {@link InvocationBuilder} instance
+   */
+  public InvocationBuilder<Void> invoke(String chaincodeName, String functionName) {
+    return new InvocationBuilder<>(this, chaincodeName, functionName);
+  }
+
+  /**
    * Send a {@link HypernateNotification}.
    *
    * <p>Notifies all middlewares in the chain (in the order in which they have been added).

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/context/InvocationBuilder.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/context/InvocationBuilder.java
@@ -18,9 +18,15 @@ public class InvocationBuilder<T> {
   private final Class<T> returnType;
   private final boolean voidReturn;
 
-  private InvocationBuilder(HypernateContext context, String chaincodeName, String functionName, 
-                            String channel, Object[] typedArgs, byte[][] rawArgs, 
-                            Class<T> returnType, boolean voidReturn) {
+  private InvocationBuilder(
+      HypernateContext context,
+      String chaincodeName,
+      String functionName,
+      String channel,
+      Object[] typedArgs,
+      byte[][] rawArgs,
+      Class<T> returnType,
+      boolean voidReturn) {
     this.context = context;
     this.chaincodeName = chaincodeName;
     this.functionName = functionName;
@@ -36,31 +42,38 @@ public class InvocationBuilder<T> {
   }
 
   public InvocationBuilder<T> onChannel(String channel) {
-    return new InvocationBuilder<>(context, chaincodeName, functionName, channel, typedArgs, rawArgs, returnType, voidReturn);
+    return new InvocationBuilder<>(
+        context, chaincodeName, functionName, channel, typedArgs, rawArgs, returnType, voidReturn);
   }
 
   public InvocationBuilder<T> withArgs(Object... args) {
-    return new InvocationBuilder<>(context, chaincodeName, functionName, channel, args, rawArgs, returnType, voidReturn);
+    return new InvocationBuilder<>(
+        context, chaincodeName, functionName, channel, args, rawArgs, returnType, voidReturn);
   }
 
   public InvocationBuilder<T> withRawArgs(byte[]... args) {
-    return new InvocationBuilder<>(context, chaincodeName, functionName, channel, typedArgs, args, returnType, voidReturn);
+    return new InvocationBuilder<>(
+        context, chaincodeName, functionName, channel, typedArgs, args, returnType, voidReturn);
   }
 
   public <R> InvocationBuilder<R> returning(Class<R> returnType) {
-    return new InvocationBuilder<>(context, chaincodeName, functionName, channel, typedArgs, rawArgs, returnType, false);
+    return new InvocationBuilder<>(
+        context, chaincodeName, functionName, channel, typedArgs, rawArgs, returnType, false);
   }
 
   public InvocationBuilder<Void> returningVoid() {
-    return new InvocationBuilder<>(context, chaincodeName, functionName, channel, typedArgs, rawArgs, null, true);
+    return new InvocationBuilder<>(
+        context, chaincodeName, functionName, channel, typedArgs, rawArgs, null, true);
   }
 
   public T execute() {
     if (rawArgs != null && typedArgs != null && typedArgs.length > 0) {
-      throw new IllegalStateException("Cannot use both withArgs() and withRawArgs() on the same invocation.");
+      throw new IllegalStateException(
+          "Cannot use both withArgs() and withRawArgs() on the same invocation.");
     }
     if (!voidReturn && returnType == null) {
-      throw new IllegalStateException("Call .returning(Class) or .returningVoid() before execute().");
+      throw new IllegalStateException(
+          "Call .returning(Class) or .returningVoid() before execute().");
     }
 
     List<byte[]> assembledArgs = new ArrayList<>();
@@ -86,7 +99,8 @@ public class InvocationBuilder<T> {
     }
 
     if (response.getStatus() != Response.Status.SUCCESS) {
-      throw new CrossChaincodeException(chaincodeName, functionName, response.getStatus().getCode(), response.getMessage());
+      throw new CrossChaincodeException(
+          chaincodeName, functionName, response.getStatus().getCode(), response.getMessage());
     }
 
     if (voidReturn) {

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/context/InvocationBuilder.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/context/InvocationBuilder.java
@@ -1,0 +1,102 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.context;
+
+import hu.bme.mit.ftsrg.hypernate.util.JSON;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.hyperledger.fabric.shim.Chaincode.Response;
+
+public class InvocationBuilder<T> {
+  private final HypernateContext context;
+  private final String chaincodeName;
+  private final String functionName;
+  private final String channel;
+  private final Object[] typedArgs;
+  private final byte[][] rawArgs;
+  private final Class<T> returnType;
+  private final boolean voidReturn;
+
+  private InvocationBuilder(HypernateContext context, String chaincodeName, String functionName, 
+                            String channel, Object[] typedArgs, byte[][] rawArgs, 
+                            Class<T> returnType, boolean voidReturn) {
+    this.context = context;
+    this.chaincodeName = chaincodeName;
+    this.functionName = functionName;
+    this.channel = channel;
+    this.typedArgs = typedArgs;
+    this.rawArgs = rawArgs;
+    this.returnType = returnType;
+    this.voidReturn = voidReturn;
+  }
+
+  public InvocationBuilder(HypernateContext context, String chaincodeName, String functionName) {
+    this(context, chaincodeName, functionName, null, new Object[0], null, null, false);
+  }
+
+  public InvocationBuilder<T> onChannel(String channel) {
+    return new InvocationBuilder<>(context, chaincodeName, functionName, channel, typedArgs, rawArgs, returnType, voidReturn);
+  }
+
+  public InvocationBuilder<T> withArgs(Object... args) {
+    return new InvocationBuilder<>(context, chaincodeName, functionName, channel, args, rawArgs, returnType, voidReturn);
+  }
+
+  public InvocationBuilder<T> withRawArgs(byte[]... args) {
+    return new InvocationBuilder<>(context, chaincodeName, functionName, channel, typedArgs, args, returnType, voidReturn);
+  }
+
+  public <R> InvocationBuilder<R> returning(Class<R> returnType) {
+    return new InvocationBuilder<>(context, chaincodeName, functionName, channel, typedArgs, rawArgs, returnType, false);
+  }
+
+  public InvocationBuilder<Void> returningVoid() {
+    return new InvocationBuilder<>(context, chaincodeName, functionName, channel, typedArgs, rawArgs, null, true);
+  }
+
+  public T execute() {
+    if (rawArgs != null && typedArgs != null && typedArgs.length > 0) {
+      throw new IllegalStateException("Cannot use both withArgs() and withRawArgs() on the same invocation.");
+    }
+    if (!voidReturn && returnType == null) {
+      throw new IllegalStateException("Call .returning(Class) or .returningVoid() before execute().");
+    }
+
+    List<byte[]> assembledArgs = new ArrayList<>();
+    assembledArgs.add(functionName.getBytes(StandardCharsets.UTF_8));
+
+    if (rawArgs != null) {
+      assembledArgs.addAll(Arrays.asList(rawArgs));
+    } else if (typedArgs != null) {
+      for (int i = 0; i < typedArgs.length; i++) {
+        try {
+          assembledArgs.add(JSON.serialize(typedArgs[i]).getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+          throw new RuntimeException("Failed to serialize typed argument at index " + i, e);
+        }
+      }
+    }
+
+    Response response;
+    if (channel != null && !channel.isEmpty()) {
+      response = context.getFabricStub().invokeChaincode(chaincodeName, assembledArgs, channel);
+    } else {
+      response = context.getFabricStub().invokeChaincode(chaincodeName, assembledArgs);
+    }
+
+    if (response.getStatus() != Response.Status.SUCCESS) {
+      throw new CrossChaincodeException(chaincodeName, functionName, response.getStatus().getCode(), response.getMessage());
+    }
+
+    if (voidReturn) {
+      return null;
+    }
+
+    try {
+      return JSON.deserialize(response.getStringPayload(), returnType);
+    } catch (Exception e) {
+      throw new CrossChaincodeDeserializationException(chaincodeName, functionName, returnType, e);
+    }
+  }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/endorsement/EndorsementPolicy.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/endorsement/EndorsementPolicy.java
@@ -1,0 +1,127 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.endorsement;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Stack;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.Getter;
+
+public class EndorsementPolicy {
+  @Getter private final String expression;
+
+  private EndorsementPolicy(String expression) {
+    this.expression = expression;
+  }
+
+  public static EndorsementPolicy of(String expression) {
+    validate(expression);
+    return new EndorsementPolicy(expression);
+  }
+
+  public static EndorsementPolicyBuilder builder() {
+    return new EndorsementPolicyBuilder();
+  }
+
+  /**
+   * NOTE: A production implementation would compile this expression to a SignaturePolicyEnvelope
+   * protobuf byte array using Fabric's msp/policydsl package. This prototype uses UTF-8-encoded
+   * expression strings for simplicity, which is not compatible with stub.setStateValidationParameter()
+   * in a real network.
+   */
+  public byte[] getPolicyBytes() {
+    return expression.getBytes(StandardCharsets.UTF_8);
+  }
+
+  private static void validate(String expr) {
+    if (expr == null || expr.isBlank()) {
+      throw new InvalidEndorsementPolicyException("Expression cannot be blank");
+    }
+
+    Stack<Integer> parenStack = new Stack<>();
+    char[] chars = expr.toCharArray();
+    for (int i = 0; i < chars.length; i++) {
+      if (chars[i] == '(') parenStack.push(i);
+      else if (chars[i] == ')') {
+        if (parenStack.isEmpty()) {
+          throw new InvalidEndorsementPolicyException("Unexpected closing parenthesis at position " + i);
+        }
+        parenStack.pop();
+      }
+    }
+    if (!parenStack.isEmpty()) {
+      throw new InvalidEndorsementPolicyException(
+          "Unclosed parenthesis: " + parenStack.size() + " opening parenthesis(es) never closed");
+    }
+
+    Pattern funcPattern = Pattern.compile("([A-Za-z]+)\\(");
+    Matcher funcMatcher = funcPattern.matcher(expr);
+    while (funcMatcher.find()) {
+      String func = funcMatcher.group(1);
+      if (!func.equals("AND") && !func.equals("OR") && !func.equals("OutOf")) {
+        throw new InvalidEndorsementPolicyException(
+            "Unsupported policy function '" + func + "'. Only AND, OR, OutOf are allowed.");
+      }
+      if (func.equals("OutOf")) {
+        int contentStart = funcMatcher.end();
+        int commaIndex = expr.indexOf(',', contentStart);
+        int closeParen = expr.indexOf(')', contentStart);
+        int firstArgEnd = (commaIndex != -1 && commaIndex < closeParen) ? commaIndex : closeParen;
+        String firstArg = expr.substring(contentStart, firstArgEnd).trim();
+        if (!firstArg.matches("\\d+")) {
+          throw new InvalidEndorsementPolicyException(
+              "OutOf() requires an integer as its first argument, found '" + firstArg + "'");
+        }
+      }
+    }
+
+    Pattern mspPattern = Pattern.compile("'([^']+)'");
+    Matcher mspMatcher = mspPattern.matcher(expr);
+    List<String> foundMsps = new ArrayList<>();
+    while (mspMatcher.find()) {
+      String msp = mspMatcher.group(1);
+      foundMsps.add(msp);
+      if (!msp.matches("^[A-Za-z0-9]+MSP\\.(peer|member|admin|client)$")) {
+        throw new InvalidEndorsementPolicyException(
+            "Invalid MSP principal '" + msp + "'. Expected format: OrgNameMSP.(peer|member|admin|client)");
+      }
+    }
+
+    if (foundMsps.isEmpty()) {
+      throw new InvalidEndorsementPolicyException("Expression contains no valid principals");
+    }
+
+    // Validate OutOf threshold semantics
+    if (expr.contains("OutOf(")) {
+        Matcher outOfMatcher = Pattern.compile("OutOf\\(\\s*(\\d+)\\s*,").matcher(expr);
+        if (outOfMatcher.find()) {
+            int threshold = Integer.parseInt(outOfMatcher.group(1));
+            // Find closing paren matching this OutOf(
+            int openIdx = outOfMatcher.end() - 1; // position of comma
+            int stack = 1;
+            int closeIdx = -1;
+            for(int i = outOfMatcher.start() + 6; i < expr.length(); i++) {
+                if (expr.charAt(i) == '(') stack++;
+                if (expr.charAt(i) == ')') {
+                    stack--;
+                    if (stack == 0) {
+                        closeIdx = i;
+                        break;
+                    }
+                }
+            }
+            if (closeIdx != -1) {
+                String outOfBody = expr.substring(outOfMatcher.end(), closeIdx);
+                Matcher innerMspMatcher = mspPattern.matcher(outOfBody);
+                int count = 0;
+                while (innerMspMatcher.find()) count++;
+                if (threshold > count) {
+                    throw new InvalidEndorsementPolicyException("OutOf threshold " + threshold + " exceeds principal count " + count);
+                }
+            }
+        }
+    }
+  }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/endorsement/EndorsementPolicy.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/endorsement/EndorsementPolicy.java
@@ -28,8 +28,8 @@ public class EndorsementPolicy {
   /**
    * NOTE: A production implementation would compile this expression to a SignaturePolicyEnvelope
    * protobuf byte array using Fabric's msp/policydsl package. This prototype uses UTF-8-encoded
-   * expression strings for simplicity, which is not compatible with stub.setStateValidationParameter()
-   * in a real network.
+   * expression strings for simplicity, which is not compatible with
+   * stub.setStateValidationParameter() in a real network.
    */
   public byte[] getPolicyBytes() {
     return expression.getBytes(StandardCharsets.UTF_8);
@@ -46,7 +46,8 @@ public class EndorsementPolicy {
       if (chars[i] == '(') parenStack.push(i);
       else if (chars[i] == ')') {
         if (parenStack.isEmpty()) {
-          throw new InvalidEndorsementPolicyException("Unexpected closing parenthesis at position " + i);
+          throw new InvalidEndorsementPolicyException(
+              "Unexpected closing parenthesis at position " + i);
         }
         parenStack.pop();
       }
@@ -85,7 +86,9 @@ public class EndorsementPolicy {
       foundMsps.add(msp);
       if (!msp.matches("^[A-Za-z0-9]+MSP\\.(peer|member|admin|client)$")) {
         throw new InvalidEndorsementPolicyException(
-            "Invalid MSP principal '" + msp + "'. Expected format: OrgNameMSP.(peer|member|admin|client)");
+            "Invalid MSP principal '"
+                + msp
+                + "'. Expected format: OrgNameMSP.(peer|member|admin|client)");
       }
     }
 
@@ -95,33 +98,34 @@ public class EndorsementPolicy {
 
     // Validate OutOf threshold semantics
     if (expr.contains("OutOf(")) {
-        Matcher outOfMatcher = Pattern.compile("OutOf\\(\\s*(\\d+)\\s*,").matcher(expr);
-        if (outOfMatcher.find()) {
-            int threshold = Integer.parseInt(outOfMatcher.group(1));
-            // Find closing paren matching this OutOf(
-            int openIdx = outOfMatcher.end() - 1; // position of comma
-            int stack = 1;
-            int closeIdx = -1;
-            for(int i = outOfMatcher.start() + 6; i < expr.length(); i++) {
-                if (expr.charAt(i) == '(') stack++;
-                if (expr.charAt(i) == ')') {
-                    stack--;
-                    if (stack == 0) {
-                        closeIdx = i;
-                        break;
-                    }
-                }
+      Matcher outOfMatcher = Pattern.compile("OutOf\\(\\s*(\\d+)\\s*,").matcher(expr);
+      if (outOfMatcher.find()) {
+        int threshold = Integer.parseInt(outOfMatcher.group(1));
+        // Find closing paren matching this OutOf(
+        int openIdx = outOfMatcher.end() - 1; // position of comma
+        int stack = 1;
+        int closeIdx = -1;
+        for (int i = outOfMatcher.start() + 6; i < expr.length(); i++) {
+          if (expr.charAt(i) == '(') stack++;
+          if (expr.charAt(i) == ')') {
+            stack--;
+            if (stack == 0) {
+              closeIdx = i;
+              break;
             }
-            if (closeIdx != -1) {
-                String outOfBody = expr.substring(outOfMatcher.end(), closeIdx);
-                Matcher innerMspMatcher = mspPattern.matcher(outOfBody);
-                int count = 0;
-                while (innerMspMatcher.find()) count++;
-                if (threshold > count) {
-                    throw new InvalidEndorsementPolicyException("OutOf threshold " + threshold + " exceeds principal count " + count);
-                }
-            }
+          }
         }
+        if (closeIdx != -1) {
+          String outOfBody = expr.substring(outOfMatcher.end(), closeIdx);
+          Matcher innerMspMatcher = mspPattern.matcher(outOfBody);
+          int count = 0;
+          while (innerMspMatcher.find()) count++;
+          if (threshold > count) {
+            throw new InvalidEndorsementPolicyException(
+                "OutOf threshold " + threshold + " exceeds principal count " + count);
+          }
+        }
+      }
     }
   }
 }

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/endorsement/EndorsementPolicyBuilder.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/endorsement/EndorsementPolicyBuilder.java
@@ -1,0 +1,85 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.endorsement;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class EndorsementPolicyBuilder {
+  private String combinator;
+  private Integer threshold;
+  private final List<String> clauses = new ArrayList<>();
+
+  public EndorsementPolicyBuilder or() {
+    this.combinator = "OR";
+    return this;
+  }
+
+  public EndorsementPolicyBuilder and() {
+    this.combinator = "AND";
+    return this;
+  }
+
+  public EndorsementPolicyBuilder outOf(int n) {
+    this.combinator = "OutOf";
+    this.threshold = n;
+    return this;
+  }
+
+  public OrgBuilder org(String orgName) {
+    return new OrgBuilder(orgName);
+  }
+
+  public EndorsementPolicy build() {
+    if (clauses.isEmpty()) {
+      throw new IllegalStateException("No principals added");
+    }
+    if (combinator == null) {
+      throw new IllegalStateException("Combinator (and/or/outOf) must be set");
+    }
+    
+    String joinedClauses = clauses.stream()
+        .map(c -> "'" + c + "'")
+        .collect(Collectors.joining(", "));
+
+    String expression;
+    if ("OutOf".equals(combinator)) {
+      if (threshold > clauses.size()) {
+        throw new IllegalStateException("OutOf threshold " + threshold + " exceeds number of principals " + clauses.size());
+      }
+      expression = String.format("OutOf(%d, %s)", threshold, joinedClauses);
+    } else {
+      expression = String.format("%s(%s)", combinator, joinedClauses);
+    }
+    
+    return EndorsementPolicy.of(expression);
+  }
+
+  public class OrgBuilder {
+    private final String orgName;
+
+    private OrgBuilder(String orgName) {
+      this.orgName = orgName;
+    }
+
+    public EndorsementPolicyBuilder peer() {
+      clauses.add(orgName + "MSP.peer");
+      return EndorsementPolicyBuilder.this;
+    }
+
+    public EndorsementPolicyBuilder member() {
+      clauses.add(orgName + "MSP.member");
+      return EndorsementPolicyBuilder.this;
+    }
+
+    public EndorsementPolicyBuilder admin() {
+      clauses.add(orgName + "MSP.admin");
+      return EndorsementPolicyBuilder.this;
+    }
+
+    public EndorsementPolicyBuilder client() {
+      clauses.add(orgName + "MSP.client");
+      return EndorsementPolicyBuilder.this;
+    }
+  }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/endorsement/EndorsementPolicyBuilder.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/endorsement/EndorsementPolicyBuilder.java
@@ -37,21 +37,21 @@ public class EndorsementPolicyBuilder {
     if (combinator == null) {
       throw new IllegalStateException("Combinator (and/or/outOf) must be set");
     }
-    
-    String joinedClauses = clauses.stream()
-        .map(c -> "'" + c + "'")
-        .collect(Collectors.joining(", "));
+
+    String joinedClauses =
+        clauses.stream().map(c -> "'" + c + "'").collect(Collectors.joining(", "));
 
     String expression;
     if ("OutOf".equals(combinator)) {
       if (threshold > clauses.size()) {
-        throw new IllegalStateException("OutOf threshold " + threshold + " exceeds number of principals " + clauses.size());
+        throw new IllegalStateException(
+            "OutOf threshold " + threshold + " exceeds number of principals " + clauses.size());
       }
       expression = String.format("OutOf(%d, %s)", threshold, joinedClauses);
     } else {
       expression = String.format("%s(%s)", combinator, joinedClauses);
     }
-    
+
     return EndorsementPolicy.of(expression);
   }
 

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/endorsement/InvalidEndorsementPolicyException.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/endorsement/InvalidEndorsementPolicyException.java
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.endorsement;
+
+public class InvalidEndorsementPolicyException extends RuntimeException {
+  public InvalidEndorsementPolicyException(String message) {
+    super(message);
+  }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/StubMiddleware.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/StubMiddleware.java
@@ -28,6 +28,10 @@ public abstract class StubMiddleware implements ChaincodeStub, Subscriber<Hypern
   /** The next {@link ChaincodeStub} in the chain. */
   @Delegate ChaincodeStub nextStub;
 
+  public ChaincodeStub getNextStub() {
+    return nextStub;
+  }
+
   @Override
   public void onSubscribe(Subscription subscription) {}
 

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/WriteBackCachedStubMiddleware.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/middleware/WriteBackCachedStubMiddleware.java
@@ -156,4 +156,8 @@ public final class WriteBackCachedStubMiddleware extends StubMiddleware {
       return this.value != null;
     }
   }
+
+  public boolean hasUncommittedState() {
+    return cache.values().stream().anyMatch(CachedItem::isDirty);
+  }
 }

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/PagedResult.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/PagedResult.java
@@ -14,7 +14,15 @@ public class PagedResult<T> {
     this.hasMore = hasMore;
   }
 
-  public List<T> results() { return results; }
-  public String nextBookmark() { return nextBookmark; }
-  public boolean hasMore() { return hasMore; }
+  public List<T> results() {
+    return results;
+  }
+
+  public String nextBookmark() {
+    return nextBookmark;
+  }
+
+  public boolean hasMore() {
+    return hasMore;
+  }
 }

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/PagedResult.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/PagedResult.java
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.registry;
+
+import java.util.List;
+
+public class PagedResult<T> {
+  private final List<T> results;
+  private final String nextBookmark;
+  private final boolean hasMore;
+
+  public PagedResult(List<T> results, String nextBookmark, boolean hasMore) {
+    this.results = results;
+    this.nextBookmark = nextBookmark;
+    this.hasMore = hasMore;
+  }
+
+  public List<T> results() { return results; }
+  public String nextBookmark() { return nextBookmark; }
+  public boolean hasMore() { return hasMore; }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/QueryResultCollector.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/QueryResultCollector.java
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.registry;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.hyperledger.fabric.shim.ledger.KeyValue;
+import org.hyperledger.fabric.shim.ledger.QueryResultsIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class QueryResultCollector {
+  private static final Logger logger = LoggerFactory.getLogger(QueryResultCollector.class);
+
+  static <T> List<T> collect(Iterable<KeyValue> iterable, Class<T> clazz) {
+    List<T> results = new java.util.ArrayList<>();
+    for (KeyValue kv : iterable) {
+      logger.debug("Deserializing entity at key: {}", kv.getKey());
+      results.add(Registry.EntityUtil.fromBuffer(kv.getValue(), clazz));
+    }
+    return results;
+  }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/QueryResultCollector.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/QueryResultCollector.java
@@ -2,10 +2,7 @@
 package hu.bme.mit.ftsrg.hypernate.registry;
 
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 import org.hyperledger.fabric.shim.ledger.KeyValue;
-import org.hyperledger.fabric.shim.ledger.QueryResultsIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/RangeQueryBuilder.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/RangeQueryBuilder.java
@@ -21,22 +21,24 @@ public class RangeQueryBuilder<T> {
 
   public RangeQueryBuilder<T> withKeyPrefix(Object... prefixParts) {
     validatePrimaryKeyConfiguration();
-    
+
     int expectedCount = Registry.EntityUtil.getPrimaryKeyCount(clazz);
     if (prefixParts.length > expectedCount) {
-      throw new InvalidRangeQueryException(String.format(
-          "Too many prefix parts for %s: provided %d, maximum is %d.", 
-          clazz.getName(), prefixParts.length, expectedCount));
+      throw new InvalidRangeQueryException(
+          String.format(
+              "Too many prefix parts for %s: provided %d, maximum is %d.",
+              clazz.getName(), prefixParts.length, expectedCount));
     }
-    
+
     for (int i = 0; i < prefixParts.length; i++) {
       if (prefixParts[i] == null) {
-        throw new InvalidRangeQueryException(String.format(
-            "Null prefix component at index %d for %s. Null composite key parts produce silently incorrect range scans.", 
-            i, clazz.getName()));
+        throw new InvalidRangeQueryException(
+            String.format(
+                "Null prefix component at index %d for %s. Null composite key parts produce silently incorrect range scans.",
+                i, clazz.getName()));
       }
     }
-    
+
     this.prefixParts = prefixParts;
     this.isFullScan = false;
     return this;
@@ -61,20 +63,25 @@ public class RangeQueryBuilder<T> {
 
   public List<T> execute() {
     if (!isFullScan && prefixParts == null) {
-      throw new InvalidRangeQueryException("execute() called without withKeyPrefix() or fullScan(). Configure the query before executing.");
+      throw new InvalidRangeQueryException(
+          "execute() called without withKeyPrefix() or fullScan(). Configure the query before executing.");
     }
-    
+
     org.hyperledger.fabric.shim.ledger.CompositeKey compositeKey = buildPartialKey();
 
     if (isPaginated) {
-      try (QueryResultsIteratorWithMetadata<org.hyperledger.fabric.shim.ledger.KeyValue> iter = 
-          registry.getStub().getStateByPartialCompositeKeyWithPagination(compositeKey, pageSize, bookmark)) {
+      try (QueryResultsIteratorWithMetadata<org.hyperledger.fabric.shim.ledger.KeyValue> iter =
+          registry
+              .getStub()
+              .getStateByPartialCompositeKeyWithPagination(compositeKey, pageSize, bookmark)) {
         return QueryResultCollector.collect(iter, clazz);
       } catch (Exception e) {
         throw new RuntimeException("Failed to close iterator or collect results", e);
       }
     } else {
-      try (org.hyperledger.fabric.shim.ledger.QueryResultsIterator<org.hyperledger.fabric.shim.ledger.KeyValue> iter = registry.getStub().getStateByPartialCompositeKey(compositeKey)) {
+      try (org.hyperledger.fabric.shim.ledger.QueryResultsIterator<
+              org.hyperledger.fabric.shim.ledger.KeyValue>
+          iter = registry.getStub().getStateByPartialCompositeKey(compositeKey)) {
         return QueryResultCollector.collect(iter, clazz);
       } catch (Exception e) {
         throw new RuntimeException("Failed to close iterator or collect results", e);
@@ -84,15 +91,19 @@ public class RangeQueryBuilder<T> {
 
   public PagedResult<T> executePaged() {
     if (!isPaginated) {
-      throw new IllegalStateException("executePaged() requires .paginated() to be configured first.");
+      throw new IllegalStateException(
+          "executePaged() requires .paginated() to be configured first.");
     }
     if (!isFullScan && prefixParts == null) {
-      throw new InvalidRangeQueryException("executePaged() called without withKeyPrefix() or fullScan().");
+      throw new InvalidRangeQueryException(
+          "executePaged() called without withKeyPrefix() or fullScan().");
     }
 
     org.hyperledger.fabric.shim.ledger.CompositeKey compositeKey = buildPartialKey();
-    try (QueryResultsIteratorWithMetadata<org.hyperledger.fabric.shim.ledger.KeyValue> iter = 
-        registry.getStub().getStateByPartialCompositeKeyWithPagination(compositeKey, pageSize, bookmark)) {
+    try (QueryResultsIteratorWithMetadata<org.hyperledger.fabric.shim.ledger.KeyValue> iter =
+        registry
+            .getStub()
+            .getStateByPartialCompositeKeyWithPagination(compositeKey, pageSize, bookmark)) {
       String nextBookmark = iter.getMetadata().getBookmark();
       boolean hasMore = !nextBookmark.isEmpty() || iter.getMetadata().getFetchedRecordsCount() > 0;
       List<T> results = QueryResultCollector.collect(iter, clazz);
@@ -104,9 +115,10 @@ public class RangeQueryBuilder<T> {
 
   private void validatePrimaryKeyConfiguration() {
     if (Registry.EntityUtil.getPrimaryKeyCount(clazz) == 0) {
-      throw new InvalidRangeQueryException(String.format(
-          "Cannot range-query %s: no @PrimaryKey annotation found. Range queries require at least one composite key field.", 
-          clazz.getName()));
+      throw new InvalidRangeQueryException(
+          String.format(
+              "Cannot range-query %s: no @PrimaryKey annotation found. Range queries require at least one composite key field.",
+              clazz.getName()));
     }
   }
 

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/RangeQueryBuilder.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/RangeQueryBuilder.java
@@ -1,0 +1,118 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.registry;
+
+import hu.bme.mit.ftsrg.hypernate.registry.query.InvalidRangeQueryException;
+import java.util.List;
+import org.hyperledger.fabric.shim.ledger.QueryResultsIteratorWithMetadata;
+
+public class RangeQueryBuilder<T> {
+  private final Registry registry;
+  private final Class<T> clazz;
+  private Object[] prefixParts;
+  private boolean isFullScan = false;
+  private boolean isPaginated = false;
+  private int pageSize;
+  private String bookmark;
+
+  public RangeQueryBuilder(Registry registry, Class<T> clazz) {
+    this.registry = registry;
+    this.clazz = clazz;
+  }
+
+  public RangeQueryBuilder<T> withKeyPrefix(Object... prefixParts) {
+    validatePrimaryKeyConfiguration();
+    
+    int expectedCount = Registry.EntityUtil.getPrimaryKeyCount(clazz);
+    if (prefixParts.length > expectedCount) {
+      throw new InvalidRangeQueryException(String.format(
+          "Too many prefix parts for %s: provided %d, maximum is %d.", 
+          clazz.getName(), prefixParts.length, expectedCount));
+    }
+    
+    for (int i = 0; i < prefixParts.length; i++) {
+      if (prefixParts[i] == null) {
+        throw new InvalidRangeQueryException(String.format(
+            "Null prefix component at index %d for %s. Null composite key parts produce silently incorrect range scans.", 
+            i, clazz.getName()));
+      }
+    }
+    
+    this.prefixParts = prefixParts;
+    this.isFullScan = false;
+    return this;
+  }
+
+  public RangeQueryBuilder<T> fullScan() {
+    validatePrimaryKeyConfiguration();
+    this.isFullScan = true;
+    this.prefixParts = new Object[0];
+    return this;
+  }
+
+  public RangeQueryBuilder<T> paginated(int pageSize, String bookmark) {
+    if (pageSize <= 0) {
+      throw new IllegalArgumentException("pageSize must be > 0");
+    }
+    this.isPaginated = true;
+    this.pageSize = pageSize;
+    this.bookmark = (bookmark == null) ? "" : bookmark;
+    return this;
+  }
+
+  public List<T> execute() {
+    if (!isFullScan && prefixParts == null) {
+      throw new InvalidRangeQueryException("execute() called without withKeyPrefix() or fullScan(). Configure the query before executing.");
+    }
+    
+    org.hyperledger.fabric.shim.ledger.CompositeKey compositeKey = buildPartialKey();
+
+    if (isPaginated) {
+      try (QueryResultsIteratorWithMetadata<org.hyperledger.fabric.shim.ledger.KeyValue> iter = 
+          registry.getStub().getStateByPartialCompositeKeyWithPagination(compositeKey, pageSize, bookmark)) {
+        return QueryResultCollector.collect(iter, clazz);
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to close iterator or collect results", e);
+      }
+    } else {
+      try (org.hyperledger.fabric.shim.ledger.QueryResultsIterator<org.hyperledger.fabric.shim.ledger.KeyValue> iter = registry.getStub().getStateByPartialCompositeKey(compositeKey)) {
+        return QueryResultCollector.collect(iter, clazz);
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to close iterator or collect results", e);
+      }
+    }
+  }
+
+  public PagedResult<T> executePaged() {
+    if (!isPaginated) {
+      throw new IllegalStateException("executePaged() requires .paginated() to be configured first.");
+    }
+    if (!isFullScan && prefixParts == null) {
+      throw new InvalidRangeQueryException("executePaged() called without withKeyPrefix() or fullScan().");
+    }
+
+    org.hyperledger.fabric.shim.ledger.CompositeKey compositeKey = buildPartialKey();
+    try (QueryResultsIteratorWithMetadata<org.hyperledger.fabric.shim.ledger.KeyValue> iter = 
+        registry.getStub().getStateByPartialCompositeKeyWithPagination(compositeKey, pageSize, bookmark)) {
+      String nextBookmark = iter.getMetadata().getBookmark();
+      boolean hasMore = !nextBookmark.isEmpty() || iter.getMetadata().getFetchedRecordsCount() > 0;
+      List<T> results = QueryResultCollector.collect(iter, clazz);
+      return new PagedResult<>(results, nextBookmark, hasMore);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to close iterator or collect results", e);
+    }
+  }
+
+  private void validatePrimaryKeyConfiguration() {
+    if (Registry.EntityUtil.getPrimaryKeyCount(clazz) == 0) {
+      throw new InvalidRangeQueryException(String.format(
+          "Cannot range-query %s: no @PrimaryKey annotation found. Range queries require at least one composite key field.", 
+          clazz.getName()));
+    }
+  }
+
+  private org.hyperledger.fabric.shim.ledger.CompositeKey buildPartialKey() {
+    String type = Registry.EntityUtil.getType(clazz);
+    String[] mappedParts = Registry.EntityUtil.mapKeyPartsToString(clazz, prefixParts);
+    return registry.getStub().createCompositeKey(type, mappedParts);
+  }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java
@@ -196,7 +196,8 @@ public class Registry {
    */
   public <T> List<T> readAll(final Class<T> clazz) {
     final String key = stub.createCompositeKey(EntityUtil.getType(clazz)).toString();
-    try (org.hyperledger.fabric.shim.ledger.QueryResultsIterator<KeyValue> iterator = stub.getStateByPartialCompositeKey(key)) {
+    try (org.hyperledger.fabric.shim.ledger.QueryResultsIterator<KeyValue> iterator =
+        stub.getStateByPartialCompositeKey(key)) {
       return collectResults(iterator, clazz);
     } catch (Exception e) {
       throw new RuntimeException("Failed to read all entities", e);
@@ -223,16 +224,14 @@ public class Registry {
     return new RangeQueryBuilder<>(this, clazz);
   }
 
-  <T> List<T> collectResults(org.hyperledger.fabric.shim.ledger.QueryResultsIterator<KeyValue> iterator, Class<T> clazz) {
+  <T> List<T> collectResults(
+      org.hyperledger.fabric.shim.ledger.QueryResultsIterator<KeyValue> iterator, Class<T> clazz) {
     Iterable<KeyValue> iterable = () -> iterator.iterator();
     return StreamSupport.stream(iterable.spliterator(), false)
         .map(
             kv -> {
               final byte[] value = kv.getValue();
-              logger.debug(
-                  "Found value at key {}: {}",
-                  kv.getKey(),
-                  Arrays.toString(value));
+              logger.debug("Found value at key {}: {}", kv.getKey(), Arrays.toString(value));
               return EntityUtil.fromBuffer(value, clazz);
             })
         .collect(Collectors.toList());
@@ -245,15 +244,21 @@ public class Registry {
    * @param policy the compiled endorsement policy
    * @param <T> the entity type
    */
-  public <T> void setEndorsementPolicy(T entity, hu.bme.mit.ftsrg.hypernate.endorsement.EndorsementPolicy policy) {
+  public <T> void setEndorsementPolicy(
+      T entity, hu.bme.mit.ftsrg.hypernate.endorsement.EndorsementPolicy policy) {
+    if (!exists(entity)) {
+      throw new EntityNotFoundException("Cannot set endorsement policy: entity does not exist");
+    }
     stub.setStateValidationParameter(getCompositeKey(entity), policy.getPolicyBytes());
   }
 
   private <T> void applyEndorsementPolicyIfPresent(T entity, String key) {
-    hu.bme.mit.ftsrg.hypernate.annotations.EndorsementPolicy annot = 
-        entity.getClass().getAnnotation(hu.bme.mit.ftsrg.hypernate.annotations.EndorsementPolicy.class);
+    hu.bme.mit.ftsrg.hypernate.annotations.EndorsementPolicy annot =
+        entity
+            .getClass()
+            .getAnnotation(hu.bme.mit.ftsrg.hypernate.annotations.EndorsementPolicy.class);
     if (annot != null) {
-      hu.bme.mit.ftsrg.hypernate.endorsement.EndorsementPolicy policy = 
+      hu.bme.mit.ftsrg.hypernate.endorsement.EndorsementPolicy policy =
           hu.bme.mit.ftsrg.hypernate.endorsement.EndorsementPolicy.of(annot.value());
       stub.setStateValidationParameter(key, policy.getPolicyBytes());
     }

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java
@@ -31,6 +31,10 @@ public class Registry {
     this.stub = stub;
   }
 
+  ChaincodeStub getStub() {
+    return stub;
+  }
+
   /**
    * Create a new entity.
    *
@@ -44,6 +48,7 @@ public class Registry {
     final String key = getCompositeKey(entity);
     final byte[] buffer = EntityUtil.toBuffer(entity);
     stub.putState(key, buffer);
+    applyEndorsementPolicyIfPresent(entity, key);
   }
 
   /**
@@ -77,6 +82,7 @@ public class Registry {
     final String key = getCompositeKey(entity);
     final byte[] buffer = EntityUtil.toBuffer(entity);
     stub.putState(key, buffer);
+    applyEndorsementPolicyIfPresent(entity, key);
   }
 
   /**
@@ -190,20 +196,67 @@ public class Registry {
    */
   public <T> List<T> readAll(final Class<T> clazz) {
     final String key = stub.createCompositeKey(EntityUtil.getType(clazz)).toString();
-    Iterator<KeyValue> iterator = stub.getStateByPartialCompositeKey(key).iterator();
-    Iterable<KeyValue> iterable = () -> iterator;
+    try (org.hyperledger.fabric.shim.ledger.QueryResultsIterator<KeyValue> iterator = stub.getStateByPartialCompositeKey(key)) {
+      return collectResults(iterator, clazz);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to read all entities", e);
+    }
+  }
+
+  /**
+   * Start a fluent CouchDB rich query for the given entity type.
+   *
+   * @param clazz the entity class
+   * @return a {@link RichQueryBuilder} instance
+   */
+  public <T> RichQueryBuilder<T> query(Class<T> clazz) {
+    return new RichQueryBuilder<>(this, clazz);
+  }
+
+  /**
+   * Start a fluent composite key range scan for the given entity type.
+   *
+   * @param clazz the entity class
+   * @return a {@link RangeQueryBuilder} instance
+   */
+  public <T> RangeQueryBuilder<T> rangeQuery(Class<T> clazz) {
+    return new RangeQueryBuilder<>(this, clazz);
+  }
+
+  <T> List<T> collectResults(org.hyperledger.fabric.shim.ledger.QueryResultsIterator<KeyValue> iterator, Class<T> clazz) {
+    Iterable<KeyValue> iterable = () -> iterator.iterator();
     return StreamSupport.stream(iterable.spliterator(), false)
         .map(
             kv -> {
               final byte[] value = kv.getValue();
               logger.debug(
-                  "Found value at partial key {}: {} -> {}",
-                  key,
+                  "Found value at key {}: {}",
                   kv.getKey(),
                   Arrays.toString(value));
               return EntityUtil.fromBuffer(value, clazz);
             })
         .collect(Collectors.toList());
+  }
+
+  /**
+   * Dynamically set a state-based endorsement policy for an asset.
+   *
+   * @param entity the entity to apply the policy to
+   * @param policy the compiled endorsement policy
+   * @param <T> the entity type
+   */
+  public <T> void setEndorsementPolicy(T entity, hu.bme.mit.ftsrg.hypernate.endorsement.EndorsementPolicy policy) {
+    stub.setStateValidationParameter(getCompositeKey(entity), policy.getPolicyBytes());
+  }
+
+  private <T> void applyEndorsementPolicyIfPresent(T entity, String key) {
+    hu.bme.mit.ftsrg.hypernate.annotations.EndorsementPolicy annot = 
+        entity.getClass().getAnnotation(hu.bme.mit.ftsrg.hypernate.annotations.EndorsementPolicy.class);
+    if (annot != null) {
+      hu.bme.mit.ftsrg.hypernate.endorsement.EndorsementPolicy policy = 
+          hu.bme.mit.ftsrg.hypernate.endorsement.EndorsementPolicy.of(annot.value());
+      stub.setStateValidationParameter(key, policy.getPolicyBytes());
+    }
   }
 
   @Loggable(Loggable.DEBUG)
@@ -237,7 +290,7 @@ public class Registry {
   }
 
   @UtilityClass
-  private class EntityUtil {
+  class EntityUtil {
 
     private final Logger logger = LoggerFactory.getLogger(EntityUtil.class);
 

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/RichQueryBuilder.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/RichQueryBuilder.java
@@ -48,8 +48,8 @@ public class RichQueryBuilder<T> {
   }
 
   /**
-   * Add a sort condition. Note: CouchDB requires an index to exist on the sorted fields.
-   * If an index does not exist, Fabric CouchDB runtime will return an error during execution.
+   * Add a sort condition. Note: CouchDB requires an index to exist on the sorted fields. If an
+   * index does not exist, Fabric CouchDB runtime will return an error during execution.
    */
   public RichQueryBuilder<T> sortBy(String field, SortOrder order) {
     this.sort.add(Map.of(field, order == SortOrder.DESC ? "desc" : "asc"));
@@ -77,14 +77,15 @@ public class RichQueryBuilder<T> {
   }
 
   /**
-   * Execute the rich query.
-   * Note: Calling execute() with no conditions will result in a full-collection scan 
-   * for the given entity type, matching all documents of this type.
+   * Execute the rich query. Note: Calling execute() with no conditions will result in a
+   * full-collection scan for the given entity type, matching all documents of this type.
    */
   public List<T> execute() throws UncommittedStateException {
     checkUncommittedState();
     String queryString = buildQueryString();
-    try (org.hyperledger.fabric.shim.ledger.QueryResultsIterator<org.hyperledger.fabric.shim.ledger.KeyValue> iter = registry.getStub().getQueryResult(queryString)) {
+    try (org.hyperledger.fabric.shim.ledger.QueryResultsIterator<
+            org.hyperledger.fabric.shim.ledger.KeyValue>
+        iter = registry.getStub().getQueryResult(queryString)) {
       return QueryResultCollector.collect(iter, clazz);
     } catch (Exception e) {
       throw new RuntimeException("Failed to close iterator or collect results", e);
@@ -96,8 +97,8 @@ public class RichQueryBuilder<T> {
     String queryString = buildQueryString();
     int pageSize = (limit != null) ? limit : 25;
     String bm = (bookmark != null) ? bookmark : "";
-    
-    try (QueryResultsIteratorWithMetadata<org.hyperledger.fabric.shim.ledger.KeyValue> iter = 
+
+    try (QueryResultsIteratorWithMetadata<org.hyperledger.fabric.shim.ledger.KeyValue> iter =
         registry.getStub().getQueryResultWithPagination(queryString, pageSize, bm)) {
       String nextBookmark = iter.getMetadata().getBookmark();
       boolean hasMore = !nextBookmark.isEmpty() || iter.getMetadata().getFetchedRecordsCount() > 0;
@@ -129,9 +130,10 @@ public class RichQueryBuilder<T> {
     while (current instanceof StubMiddleware sm) {
       if (current instanceof WriteBackCachedStubMiddleware wbc) {
         if (wbc.hasUncommittedState()) {
-          throw new UncommittedStateException("Rich query cannot proceed: uncommitted writes exist in the middleware cache. "
-              + "CouchDB reads committed ledger state only — buffered writes in WriteBackCachedStubMiddleware are invisible to getQueryResult(). "
-              + "Flush pending writes via ctx.notify(new TransactionEnd()) before querying, or restructure your transaction to query before writing.");
+          throw new UncommittedStateException(
+              "Rich query cannot proceed: uncommitted writes exist in the middleware cache. "
+                  + "CouchDB reads committed ledger state only — buffered writes in WriteBackCachedStubMiddleware are invisible to getQueryResult(). "
+                  + "Flush pending writes via ctx.notify(new TransactionEnd()) before querying, or restructure your transaction to query before writing.");
         }
       }
       current = sm.getNextStub();

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/RichQueryBuilder.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/RichQueryBuilder.java
@@ -1,0 +1,204 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.registry;
+
+import hu.bme.mit.ftsrg.hypernate.middleware.StubMiddleware;
+import hu.bme.mit.ftsrg.hypernate.middleware.WriteBackCachedStubMiddleware;
+import hu.bme.mit.ftsrg.hypernate.registry.query.UncommittedStateException;
+import hu.bme.mit.ftsrg.hypernate.util.JSON;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.hyperledger.fabric.shim.ChaincodeStub;
+import org.hyperledger.fabric.shim.ledger.QueryResultsIteratorWithMetadata;
+
+public class RichQueryBuilder<T> {
+
+  private final Registry registry;
+  private final Class<T> clazz;
+  private final SelectorBuilder selectorBuilder = new SelectorBuilder();
+  private final List<Map<String, String>> sort = new ArrayList<>();
+  private String bookmark;
+  private List<String> useIndex;
+  private Integer limit;
+  private Integer skip;
+
+  public RichQueryBuilder(Registry registry, Class<T> clazz) {
+    this.registry = registry;
+    this.clazz = clazz;
+    this.selectorBuilder.addCondition("docType", "$eq", Registry.EntityUtil.getType(clazz));
+  }
+
+  public ConditionBuilder where(String field) {
+    return new ConditionBuilder(field);
+  }
+
+  public ConditionBuilder and(String field) {
+    return new ConditionBuilder(field);
+  }
+
+  public RichQueryBuilder<T> or(RichQueryBuilder<T>... subQueries) {
+    List<Map<String, Object>> subSelectors = new ArrayList<>();
+    for (RichQueryBuilder<T> sq : subQueries) {
+      subSelectors.add(sq.selectorBuilder.build());
+    }
+    selectorBuilder.addOr(subSelectors);
+    return this;
+  }
+
+  /**
+   * Add a sort condition. Note: CouchDB requires an index to exist on the sorted fields.
+   * If an index does not exist, Fabric CouchDB runtime will return an error during execution.
+   */
+  public RichQueryBuilder<T> sortBy(String field, SortOrder order) {
+    this.sort.add(Map.of(field, order == SortOrder.DESC ? "desc" : "asc"));
+    return this;
+  }
+
+  public RichQueryBuilder<T> useIndex(String designDoc, String indexName) {
+    this.useIndex = Arrays.asList(designDoc, indexName);
+    return this;
+  }
+
+  public RichQueryBuilder<T> bookmark(String token) {
+    this.bookmark = token;
+    return this;
+  }
+
+  public RichQueryBuilder<T> limit(int n) {
+    this.limit = n;
+    return this;
+  }
+
+  public RichQueryBuilder<T> skip(int n) {
+    this.skip = n;
+    return this;
+  }
+
+  /**
+   * Execute the rich query.
+   * Note: Calling execute() with no conditions will result in a full-collection scan 
+   * for the given entity type, matching all documents of this type.
+   */
+  public List<T> execute() throws UncommittedStateException {
+    checkUncommittedState();
+    String queryString = buildQueryString();
+    try (org.hyperledger.fabric.shim.ledger.QueryResultsIterator<org.hyperledger.fabric.shim.ledger.KeyValue> iter = registry.getStub().getQueryResult(queryString)) {
+      return QueryResultCollector.collect(iter, clazz);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to close iterator or collect results", e);
+    }
+  }
+
+  public PagedResult<T> executePaged() throws UncommittedStateException {
+    checkUncommittedState();
+    String queryString = buildQueryString();
+    int pageSize = (limit != null) ? limit : 25;
+    String bm = (bookmark != null) ? bookmark : "";
+    
+    try (QueryResultsIteratorWithMetadata<org.hyperledger.fabric.shim.ledger.KeyValue> iter = 
+        registry.getStub().getQueryResultWithPagination(queryString, pageSize, bm)) {
+      String nextBookmark = iter.getMetadata().getBookmark();
+      boolean hasMore = !nextBookmark.isEmpty() || iter.getMetadata().getFetchedRecordsCount() > 0;
+      List<T> results = QueryResultCollector.collect(iter, clazz);
+      return new PagedResult<>(results, nextBookmark, hasMore);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to close iterator or collect results", e);
+    }
+  }
+
+  private String buildQueryString() {
+    Map<String, Object> query = new HashMap<>();
+    query.put("selector", selectorBuilder.build());
+    if (!sort.isEmpty()) query.put("sort", sort);
+    if (useIndex != null) query.put("use_index", useIndex);
+    if (bookmark != null) query.put("bookmark", bookmark);
+    if (limit != null) query.put("limit", limit);
+    if (skip != null) query.put("skip", skip);
+
+    try {
+      return JSON.serialize(query);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to serialize CouchDB query", e);
+    }
+  }
+
+  private void checkUncommittedState() throws UncommittedStateException {
+    ChaincodeStub current = registry.getStub();
+    while (current instanceof StubMiddleware sm) {
+      if (current instanceof WriteBackCachedStubMiddleware wbc) {
+        if (wbc.hasUncommittedState()) {
+          throw new UncommittedStateException("Rich query cannot proceed: uncommitted writes exist in the middleware cache. "
+              + "CouchDB reads committed ledger state only — buffered writes in WriteBackCachedStubMiddleware are invisible to getQueryResult(). "
+              + "Flush pending writes via ctx.notify(new TransactionEnd()) before querying, or restructure your transaction to query before writing.");
+        }
+      }
+      current = sm.getNextStub();
+    }
+  }
+
+  public class ConditionBuilder {
+    private final String field;
+
+    private ConditionBuilder(String field) {
+      this.field = field;
+    }
+
+    public RichQueryBuilder<T> is(Object value) {
+      selectorBuilder.addCondition(field, "$eq", value);
+      return RichQueryBuilder.this;
+    }
+
+    public RichQueryBuilder<T> isNot(Object value) {
+      selectorBuilder.addCondition(field, "$ne", value);
+      return RichQueryBuilder.this;
+    }
+
+    public RichQueryBuilder<T> greaterThan(Object value) {
+      selectorBuilder.addCondition(field, "$gt", value);
+      return RichQueryBuilder.this;
+    }
+
+    public RichQueryBuilder<T> greaterThanOrEq(Object value) {
+      selectorBuilder.addCondition(field, "$gte", value);
+      return RichQueryBuilder.this;
+    }
+
+    public RichQueryBuilder<T> lessThan(Object value) {
+      selectorBuilder.addCondition(field, "$lt", value);
+      return RichQueryBuilder.this;
+    }
+
+    public RichQueryBuilder<T> lessThanOrEq(Object value) {
+      selectorBuilder.addCondition(field, "$lte", value);
+      return RichQueryBuilder.this;
+    }
+
+    public RichQueryBuilder<T> in(Object... values) {
+      selectorBuilder.addCondition(field, "$in", Arrays.asList(values));
+      return RichQueryBuilder.this;
+    }
+
+    public RichQueryBuilder<T> notIn(Object... values) {
+      selectorBuilder.addCondition(field, "$nin", Arrays.asList(values));
+      return RichQueryBuilder.this;
+    }
+
+    public RichQueryBuilder<T> exists(boolean present) {
+      selectorBuilder.addCondition(field, "$exists", present);
+      return RichQueryBuilder.this;
+    }
+
+    public RichQueryBuilder<T> regex(String pattern) {
+      selectorBuilder.addCondition(field, "$regex", pattern);
+      return RichQueryBuilder.this;
+    }
+
+    public RichQueryBuilder<T> between(Object low, Object high) {
+      selectorBuilder.addCondition(field, "$gte", low);
+      selectorBuilder.addCondition(field, "$lte", high);
+      return RichQueryBuilder.this;
+    }
+  }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/SelectorBuilder.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/SelectorBuilder.java
@@ -54,7 +54,8 @@ class SelectorBuilder {
     if (!orConditions.isEmpty()) {
       if (finalSelector.containsKey("$or")) {
         @SuppressWarnings("unchecked")
-        List<Map<String, Object>> existingOrs = (List<Map<String, Object>>) finalSelector.get("$or");
+        List<Map<String, Object>> existingOrs =
+            (List<Map<String, Object>>) finalSelector.get("$or");
         existingOrs.addAll(orConditions);
       } else {
         finalSelector.put("$or", new ArrayList<>(orConditions));

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/SelectorBuilder.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/SelectorBuilder.java
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.registry;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class SelectorBuilder {
+  private final Map<String, Object> selector = new HashMap<>();
+  private final List<Map<String, Object>> orConditions = new ArrayList<>();
+
+  @SuppressWarnings("unchecked")
+  void addCondition(String field, String operator, Object value) {
+    Object existing = selector.get(field);
+
+    if (existing == null) {
+      if (operator.equals("$eq")) {
+        selector.put(field, value);
+      } else {
+        Map<String, Object> fieldConditions = new HashMap<>();
+        fieldConditions.put(operator, value);
+        selector.put(field, fieldConditions);
+      }
+    } else if (existing instanceof Map && !((Map<?, ?>) existing).containsKey(operator)) {
+      ((Map<String, Object>) existing).put(operator, value);
+    } else {
+      List<Map<String, Object>> andList;
+      if (selector.containsKey("$and")) {
+        andList = (List<Map<String, Object>>) selector.get("$and");
+      } else {
+        andList = new ArrayList<>();
+        selector.put("$and", andList);
+      }
+
+      Map<String, Object> newCond = new HashMap<>();
+      if (operator.equals("$eq")) {
+        newCond.put(field, value);
+      } else {
+        newCond.put(field, Map.of(operator, value));
+      }
+      andList.add(newCond);
+    }
+  }
+
+  void addOr(List<Map<String, Object>> subSelectors) {
+    if (subSelectors != null && !subSelectors.isEmpty()) {
+      orConditions.addAll(subSelectors);
+    }
+  }
+
+  Map<String, Object> build() {
+    Map<String, Object> finalSelector = new HashMap<>(selector);
+    if (!orConditions.isEmpty()) {
+      if (finalSelector.containsKey("$or")) {
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> existingOrs = (List<Map<String, Object>>) finalSelector.get("$or");
+        existingOrs.addAll(orConditions);
+      } else {
+        finalSelector.put("$or", new ArrayList<>(orConditions));
+      }
+    }
+    return finalSelector;
+  }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/SortOrder.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/SortOrder.java
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.registry;
+
+public enum SortOrder {
+  ASC, DESC
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/SortOrder.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/SortOrder.java
@@ -2,5 +2,6 @@
 package hu.bme.mit.ftsrg.hypernate.registry;
 
 public enum SortOrder {
-  ASC, DESC
+  ASC,
+  DESC
 }

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/query/InvalidRangeQueryException.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/query/InvalidRangeQueryException.java
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.registry.query;
+
+public class InvalidRangeQueryException extends RuntimeException {
+  public InvalidRangeQueryException(String message) {
+    super(message);
+  }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/query/UncommittedStateException.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/query/UncommittedStateException.java
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.registry.query;
+
+public class UncommittedStateException extends Exception {
+  public UncommittedStateException(String message) {
+    super(message);
+  }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/Asset.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/Asset.java
@@ -4,10 +4,7 @@ package hu.bme.mit.ftsrg.hypernate.sample;
 import hu.bme.mit.ftsrg.hypernate.annotations.AttributeInfo;
 import hu.bme.mit.ftsrg.hypernate.annotations.PrimaryKey;
 
-@PrimaryKey({
-  @AttributeInfo(name = "owner"),
-  @AttributeInfo(name = "id")
-})
+@PrimaryKey({@AttributeInfo(name = "owner"), @AttributeInfo(name = "id")})
 public class Asset {
   private String id;
   private String color;
@@ -29,7 +26,14 @@ public class Asset {
     this.value = value;
   }
 
-  public Asset(String id, String color, int size, String owner, int value, long timestamp, AssetStatus status) {
+  public Asset(
+      String id,
+      String color,
+      int size,
+      String owner,
+      int value,
+      long timestamp,
+      AssetStatus status) {
     this.id = id;
     this.color = color;
     this.size = size;
@@ -40,18 +44,59 @@ public class Asset {
   }
 
   // Getters and Setters
-  public String getId() { return id; }
-  public void setId(String id) { this.id = id; }
-  public String getColor() { return color; }
-  public void setColor(String color) { this.color = color; }
-  public int getSize() { return size; }
-  public void setSize(int size) { this.size = size; }
-  public String getOwner() { return owner; }
-  public void setOwner(String owner) { this.owner = owner; }
-  public int getValue() { return value; }
-  public void setValue(int value) { this.value = value; }
-  public long getTimestamp() { return timestamp; }
-  public void setTimestamp(long timestamp) { this.timestamp = timestamp; }
-  public AssetStatus getStatus() { return status; }
-  public void setStatus(AssetStatus status) { this.status = status; }
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getColor() {
+    return color;
+  }
+
+  public void setColor(String color) {
+    this.color = color;
+  }
+
+  public int getSize() {
+    return size;
+  }
+
+  public void setSize(int size) {
+    this.size = size;
+  }
+
+  public String getOwner() {
+    return owner;
+  }
+
+  public void setOwner(String owner) {
+    this.owner = owner;
+  }
+
+  public int getValue() {
+    return value;
+  }
+
+  public void setValue(int value) {
+    this.value = value;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(long timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public AssetStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(AssetStatus status) {
+    this.status = status;
+  }
 }

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/Asset.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/Asset.java
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.sample;
+
+import hu.bme.mit.ftsrg.hypernate.annotations.AttributeInfo;
+import hu.bme.mit.ftsrg.hypernate.annotations.PrimaryKey;
+
+@PrimaryKey({
+  @AttributeInfo(name = "owner"),
+  @AttributeInfo(name = "id")
+})
+public class Asset {
+  private String id;
+  private String color;
+  private int size;
+  private String owner;
+  private int value;
+
+  private long timestamp;
+  private AssetStatus status;
+
+  // Constructors
+  public Asset() {}
+
+  public Asset(String id, String color, int size, String owner, int value) {
+    this.id = id;
+    this.color = color;
+    this.size = size;
+    this.owner = owner;
+    this.value = value;
+  }
+
+  public Asset(String id, String color, int size, String owner, int value, long timestamp, AssetStatus status) {
+    this.id = id;
+    this.color = color;
+    this.size = size;
+    this.owner = owner;
+    this.value = value;
+    this.timestamp = timestamp;
+    this.status = status;
+  }
+
+  // Getters and Setters
+  public String getId() { return id; }
+  public void setId(String id) { this.id = id; }
+  public String getColor() { return color; }
+  public void setColor(String color) { this.color = color; }
+  public int getSize() { return size; }
+  public void setSize(int size) { this.size = size; }
+  public String getOwner() { return owner; }
+  public void setOwner(String owner) { this.owner = owner; }
+  public int getValue() { return value; }
+  public void setValue(int value) { this.value = value; }
+  public long getTimestamp() { return timestamp; }
+  public void setTimestamp(long timestamp) { this.timestamp = timestamp; }
+  public AssetStatus getStatus() { return status; }
+  public void setStatus(AssetStatus status) { this.status = status; }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/AssetStatus.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/AssetStatus.java
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.sample;
+
+public enum AssetStatus {
+  ACTIVE, PENDING_TRANSFER, ARCHIVED
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/AssetStatus.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/AssetStatus.java
@@ -2,5 +2,7 @@
 package hu.bme.mit.ftsrg.hypernate.sample;
 
 public enum AssetStatus {
-  ACTIVE, PENDING_TRANSFER, ARCHIVED
+  ACTIVE,
+  PENDING_TRANSFER,
+  ARCHIVED
 }

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/PricingRequest.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/PricingRequest.java
@@ -16,13 +16,35 @@ public class PricingRequest {
     this.offeredPrice = offeredPrice;
   }
 
-  public String assetId() { return assetId; }
-  public int currentValue() { return currentValue; }
-  public String newOwner() { return newOwner; }
-  public int offeredPrice() { return offeredPrice; }
+  public String assetId() {
+    return assetId;
+  }
 
-  public String getAssetId() { return assetId; }
-  public int getCurrentValue() { return currentValue; }
-  public String getNewOwner() { return newOwner; }
-  public int getOfferedPrice() { return offeredPrice; }
+  public int currentValue() {
+    return currentValue;
+  }
+
+  public String newOwner() {
+    return newOwner;
+  }
+
+  public int offeredPrice() {
+    return offeredPrice;
+  }
+
+  public String getAssetId() {
+    return assetId;
+  }
+
+  public int getCurrentValue() {
+    return currentValue;
+  }
+
+  public String getNewOwner() {
+    return newOwner;
+  }
+
+  public int getOfferedPrice() {
+    return offeredPrice;
+  }
 }

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/PricingRequest.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/PricingRequest.java
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.sample;
+
+public class PricingRequest {
+  private String assetId;
+  private int currentValue;
+  private String newOwner;
+  private int offeredPrice;
+
+  public PricingRequest() {}
+
+  public PricingRequest(String assetId, int currentValue, String newOwner, int offeredPrice) {
+    this.assetId = assetId;
+    this.currentValue = currentValue;
+    this.newOwner = newOwner;
+    this.offeredPrice = offeredPrice;
+  }
+
+  public String assetId() { return assetId; }
+  public int currentValue() { return currentValue; }
+  public String newOwner() { return newOwner; }
+  public int offeredPrice() { return offeredPrice; }
+
+  public String getAssetId() { return assetId; }
+  public int getCurrentValue() { return currentValue; }
+  public String getNewOwner() { return newOwner; }
+  public int getOfferedPrice() { return offeredPrice; }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/PricingResponse.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/PricingResponse.java
@@ -14,11 +14,27 @@ public class PricingResponse {
     this.notes = notes;
   }
 
-  public boolean valid() { return valid; }
-  public int approvedPrice() { return approvedPrice; }
-  public String notes() { return notes; }
+  public boolean valid() {
+    return valid;
+  }
 
-  public boolean isValid() { return valid; }
-  public int getApprovedPrice() { return approvedPrice; }
-  public String getNotes() { return notes; }
+  public int approvedPrice() {
+    return approvedPrice;
+  }
+
+  public String notes() {
+    return notes;
+  }
+
+  public boolean isValid() {
+    return valid;
+  }
+
+  public int getApprovedPrice() {
+    return approvedPrice;
+  }
+
+  public String getNotes() {
+    return notes;
+  }
 }

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/PricingResponse.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/PricingResponse.java
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.sample;
+
+public class PricingResponse {
+  private boolean valid;
+  private int approvedPrice;
+  private String notes;
+
+  public PricingResponse() {}
+
+  public PricingResponse(boolean valid, int approvedPrice, String notes) {
+    this.valid = valid;
+    this.approvedPrice = approvedPrice;
+    this.notes = notes;
+  }
+
+  public boolean valid() { return valid; }
+  public int approvedPrice() { return approvedPrice; }
+  public String notes() { return notes; }
+
+  public boolean isValid() { return valid; }
+  public int getApprovedPrice() { return approvedPrice; }
+  public String getNotes() { return notes; }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/SampleChaincode.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/SampleChaincode.java
@@ -7,7 +7,6 @@ import hu.bme.mit.ftsrg.hypernate.registry.Registry;
 import hu.bme.mit.ftsrg.hypernate.registry.SortOrder;
 import hu.bme.mit.ftsrg.hypernate.registry.query.UncommittedStateException;
 import hu.bme.mit.ftsrg.hypernate.util.JSON;
-import java.time.Instant;
 import java.util.List;
 import org.hyperledger.fabric.contract.Context;
 import org.hyperledger.fabric.contract.ContractInterface;
@@ -18,15 +17,23 @@ import org.hyperledger.fabric.contract.annotation.Transaction;
 
 @Contract(
     name = "SampleChaincode",
-    info = @Info(title = "SampleChaincode", description = "A sample Hypernate chaincode", version = "1.0"))
+    info =
+        @Info(
+            title = "SampleChaincode",
+            description = "A sample Hypernate chaincode",
+            version = "1.0"))
 @Default
 public class SampleChaincode implements ContractInterface {
 
   @Transaction
-  public void createAsset(HypernateContext ctx, String id, String color, int size, String owner, int value) {
-    if (id == null || id.isBlank()) throw new IllegalArgumentException("Field 'id' must not be blank");
-    if (color == null || color.isBlank()) throw new IllegalArgumentException("Field 'color' must not be blank");
-    if (owner == null || owner.isBlank()) throw new IllegalArgumentException("Field 'owner' must not be blank");
+  public void createAsset(
+      HypernateContext ctx, String id, String color, int size, String owner, int value) {
+    if (id == null || id.isBlank())
+      throw new IllegalArgumentException("Field 'id' must not be blank");
+    if (color == null || color.isBlank())
+      throw new IllegalArgumentException("Field 'color' must not be blank");
+    if (owner == null || owner.isBlank())
+      throw new IllegalArgumentException("Field 'owner' must not be blank");
     if (size <= 0) throw new IllegalArgumentException("Field 'size' must be positive");
     if (value <= 0) throw new IllegalArgumentException("Field 'value' must be positive");
 
@@ -36,10 +43,21 @@ public class SampleChaincode implements ContractInterface {
   }
 
   @Transaction
-  public void createSensitiveAsset(HypernateContext ctx, String id, String color, int size, String owner, int value, String classLevel, String orgsJson) {
-    if (id == null || id.isBlank()) throw new IllegalArgumentException("Field 'id' must not be blank");
-    if (color == null || color.isBlank()) throw new IllegalArgumentException("Field 'color' must not be blank");
-    if (owner == null || owner.isBlank()) throw new IllegalArgumentException("Field 'owner' must not be blank");
+  public void createSensitiveAsset(
+      HypernateContext ctx,
+      String id,
+      String color,
+      int size,
+      String owner,
+      int value,
+      String classLevel,
+      String orgsJson) {
+    if (id == null || id.isBlank())
+      throw new IllegalArgumentException("Field 'id' must not be blank");
+    if (color == null || color.isBlank())
+      throw new IllegalArgumentException("Field 'color' must not be blank");
+    if (owner == null || owner.isBlank())
+      throw new IllegalArgumentException("Field 'owner' must not be blank");
     if (size <= 0) throw new IllegalArgumentException("Field 'size' must be positive");
     if (value <= 0) throw new IllegalArgumentException("Field 'value' must be positive");
 
@@ -53,8 +71,10 @@ public class SampleChaincode implements ContractInterface {
     }
 
     long timestampMs = ctx.getStub().getTxTimestamp().toEpochMilli();
-    
-    SensitiveAsset sensitiveAsset = new SensitiveAsset(id, color, size, owner, value, timestampMs, AssetStatus.ACTIVE, classLevel, orgs);
+
+    SensitiveAsset sensitiveAsset =
+        new SensitiveAsset(
+            id, color, size, owner, value, timestampMs, AssetStatus.ACTIVE, classLevel, orgs);
     ctx.getRegistry().mustCreate(sensitiveAsset);
   }
 
@@ -64,12 +84,17 @@ public class SampleChaincode implements ContractInterface {
   }
 
   @Transaction
-  public List<Asset> queryAssetsByColorAndOwner(HypernateContext ctx, String color, String owner1, String owner2) {
+  public List<Asset> queryAssetsByColorAndOwner(
+      HypernateContext ctx, String color, String owner1, String owner2) {
     try {
-      return ctx.getRegistry().query(Asset.class)
-          .where("color").is(color)
-          .and("owner").in(owner1, owner2)
-          .and("status").is(AssetStatus.ACTIVE.name())
+      return ctx.getRegistry()
+          .query(Asset.class)
+          .where("color")
+          .is(color)
+          .and("owner")
+          .in(owner1, owner2)
+          .and("status")
+          .is(AssetStatus.ACTIVE.name())
           .sortBy("value", SortOrder.DESC)
           .limit(100)
           .execute();
@@ -82,9 +107,12 @@ public class SampleChaincode implements ContractInterface {
   public List<Asset> queryAssetsByValueRange(HypernateContext ctx, int minValue, int maxValue) {
     if (minValue > maxValue) throw new IllegalArgumentException("minValue must be <= maxValue");
     try {
-      return ctx.getRegistry().query(Asset.class)
-          .where("value").between(minValue, maxValue)
-          .and("status").isNot(AssetStatus.ARCHIVED.name())
+      return ctx.getRegistry()
+          .query(Asset.class)
+          .where("value")
+          .between(minValue, maxValue)
+          .and("status")
+          .isNot(AssetStatus.ARCHIVED.name())
           .sortBy("value", SortOrder.ASC)
           .execute();
     } catch (UncommittedStateException e) {
@@ -103,22 +131,30 @@ public class SampleChaincode implements ContractInterface {
   }
 
   @Transaction
-  public Asset initiateTransfer(HypernateContext ctx, String assetId, String currentOwner, String newOwner, int agreedPrice) {
+  public Asset initiateTransfer(
+      HypernateContext ctx, String assetId, String currentOwner, String newOwner, int agreedPrice) {
     Registry registry = ctx.getRegistry();
     Asset asset = registry.mustRead(Asset.class, currentOwner, assetId);
-    
+
     if (asset.getStatus() != AssetStatus.ACTIVE) {
-      throw new RuntimeException(String.format("Asset %s is not in ACTIVE status; current status: %s. Only ACTIVE assets can be transferred.", assetId, asset.getStatus()));
+      throw new RuntimeException(
+          String.format(
+              "Asset %s is not in ACTIVE status; current status: %s. Only ACTIVE assets can be transferred.",
+              assetId, asset.getStatus()));
     }
     if (!asset.getOwner().equals(currentOwner)) {
-      throw new RuntimeException(String.format("Owner mismatch: asset %s is owned by %s, not %s", assetId, asset.getOwner(), currentOwner));
+      throw new RuntimeException(
+          String.format(
+              "Owner mismatch: asset %s is owned by %s, not %s",
+              assetId, asset.getOwner(), currentOwner));
     }
 
-    PricingResponse pricing = ctx.invoke("PricingChaincode", "validatePrice")
-        .withArgs(new PricingRequest(assetId, asset.getValue(), newOwner, agreedPrice))
-        .returning(PricingResponse.class)
-        .execute();
-        
+    PricingResponse pricing =
+        ctx.invoke("PricingChaincode", "validatePrice")
+            .withArgs(new PricingRequest(assetId, asset.getValue(), newOwner, agreedPrice))
+            .returning(PricingResponse.class)
+            .execute();
+
     if (!pricing.valid()) {
       throw new RuntimeException("Transfer rejected by PricingChaincode: " + pricing.notes());
     }
@@ -129,12 +165,15 @@ public class SampleChaincode implements ContractInterface {
   }
 
   @Transaction
-  public Asset completeTransfer(HypernateContext ctx, String assetId, String currentOwner, String newOwner) {
+  public Asset completeTransfer(
+      HypernateContext ctx, String assetId, String currentOwner, String newOwner) {
     Registry registry = ctx.getRegistry();
     Asset asset = registry.mustRead(Asset.class, currentOwner, assetId);
 
     if (asset.getStatus() != AssetStatus.PENDING_TRANSFER) {
-      throw new RuntimeException(String.format("Asset %s is not pending transfer; status: %s", assetId, asset.getStatus()));
+      throw new RuntimeException(
+          String.format(
+              "Asset %s is not pending transfer; status: %s", assetId, asset.getStatus()));
     }
 
     asset.setOwner(newOwner);
@@ -155,7 +194,8 @@ public class SampleChaincode implements ContractInterface {
   }
 
   @Transaction
-  public void setSensitiveAssetPolicy(HypernateContext ctx, String id, String owner, String expression) {
+  public void setSensitiveAssetPolicy(
+      HypernateContext ctx, String id, String owner, String expression) {
     SensitiveAsset asset = ctx.getRegistry().mustRead(SensitiveAsset.class, owner, id);
     EndorsementPolicy policy = EndorsementPolicy.of(expression);
     ctx.getRegistry().setEndorsementPolicy(asset, policy);
@@ -164,7 +204,8 @@ public class SampleChaincode implements ContractInterface {
 
 @Contract(
     name = "PricingChaincode",
-    info = @Info(title = "PricingChaincode", description = "Mock pricing chaincode", version = "1.0"))
+    info =
+        @Info(title = "PricingChaincode", description = "Mock pricing chaincode", version = "1.0"))
 class PricingChaincode implements ContractInterface {
 
   @Transaction
@@ -175,18 +216,29 @@ class PricingChaincode implements ContractInterface {
     } catch (Exception e) {
       throw new IllegalArgumentException("Invalid JSON for PricingRequest: " + e.getMessage(), e);
     }
-    
+
     if (req.currentValue() > 1000) {
       boolean approved = req.offeredPrice() >= req.currentValue() * 0.9;
       if (!approved) {
         try {
-          return JSON.serialize(new PricingResponse(false, 0, 
-              String.format("Offered price %d is below 90%% of market value %d", req.offeredPrice(), req.currentValue())));
-        } catch (Exception e) { throw new RuntimeException(e); }
+          return JSON.serialize(
+              new PricingResponse(
+                  false,
+                  0,
+                  String.format(
+                      "Offered price %d is below 90%% of market value %d",
+                      req.offeredPrice(), req.currentValue())));
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
       }
     }
     try {
-      return JSON.serialize(new PricingResponse(true, req.offeredPrice(), "Transfer approved at price " + req.offeredPrice()));
-    } catch (Exception e) { throw new RuntimeException(e); }
+      return JSON.serialize(
+          new PricingResponse(
+              true, req.offeredPrice(), "Transfer approved at price " + req.offeredPrice()));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/SampleChaincode.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/SampleChaincode.java
@@ -1,0 +1,192 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.sample;
+
+import hu.bme.mit.ftsrg.hypernate.context.HypernateContext;
+import hu.bme.mit.ftsrg.hypernate.endorsement.EndorsementPolicy;
+import hu.bme.mit.ftsrg.hypernate.registry.Registry;
+import hu.bme.mit.ftsrg.hypernate.registry.SortOrder;
+import hu.bme.mit.ftsrg.hypernate.registry.query.UncommittedStateException;
+import hu.bme.mit.ftsrg.hypernate.util.JSON;
+import java.time.Instant;
+import java.util.List;
+import org.hyperledger.fabric.contract.Context;
+import org.hyperledger.fabric.contract.ContractInterface;
+import org.hyperledger.fabric.contract.annotation.Contract;
+import org.hyperledger.fabric.contract.annotation.Default;
+import org.hyperledger.fabric.contract.annotation.Info;
+import org.hyperledger.fabric.contract.annotation.Transaction;
+
+@Contract(
+    name = "SampleChaincode",
+    info = @Info(title = "SampleChaincode", description = "A sample Hypernate chaincode", version = "1.0"))
+@Default
+public class SampleChaincode implements ContractInterface {
+
+  @Transaction
+  public void createAsset(HypernateContext ctx, String id, String color, int size, String owner, int value) {
+    if (id == null || id.isBlank()) throw new IllegalArgumentException("Field 'id' must not be blank");
+    if (color == null || color.isBlank()) throw new IllegalArgumentException("Field 'color' must not be blank");
+    if (owner == null || owner.isBlank()) throw new IllegalArgumentException("Field 'owner' must not be blank");
+    if (size <= 0) throw new IllegalArgumentException("Field 'size' must be positive");
+    if (value <= 0) throw new IllegalArgumentException("Field 'value' must be positive");
+
+    long timestampMs = ctx.getStub().getTxTimestamp().toEpochMilli();
+    Asset asset = new Asset(id, color, size, owner, value, timestampMs, AssetStatus.ACTIVE);
+    ctx.getRegistry().mustCreate(asset);
+  }
+
+  @Transaction
+  public void createSensitiveAsset(HypernateContext ctx, String id, String color, int size, String owner, int value, String classLevel, String orgsJson) {
+    if (id == null || id.isBlank()) throw new IllegalArgumentException("Field 'id' must not be blank");
+    if (color == null || color.isBlank()) throw new IllegalArgumentException("Field 'color' must not be blank");
+    if (owner == null || owner.isBlank()) throw new IllegalArgumentException("Field 'owner' must not be blank");
+    if (size <= 0) throw new IllegalArgumentException("Field 'size' must be positive");
+    if (value <= 0) throw new IllegalArgumentException("Field 'value' must be positive");
+
+    List<String> orgs;
+    try {
+      @SuppressWarnings("unchecked")
+      List<String> parsed = JSON.deserialize(orgsJson, List.class);
+      orgs = parsed;
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Failed to deserialize orgsJson: " + e.getMessage(), e);
+    }
+
+    long timestampMs = ctx.getStub().getTxTimestamp().toEpochMilli();
+    
+    SensitiveAsset sensitiveAsset = new SensitiveAsset(id, color, size, owner, value, timestampMs, AssetStatus.ACTIVE, classLevel, orgs);
+    ctx.getRegistry().mustCreate(sensitiveAsset);
+  }
+
+  @Transaction
+  public Asset getAsset(HypernateContext ctx, String owner, String id) {
+    return ctx.getRegistry().mustRead(Asset.class, owner, id);
+  }
+
+  @Transaction
+  public List<Asset> queryAssetsByColorAndOwner(HypernateContext ctx, String color, String owner1, String owner2) {
+    try {
+      return ctx.getRegistry().query(Asset.class)
+          .where("color").is(color)
+          .and("owner").in(owner1, owner2)
+          .and("status").is(AssetStatus.ACTIVE.name())
+          .sortBy("value", SortOrder.DESC)
+          .limit(100)
+          .execute();
+    } catch (UncommittedStateException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Transaction
+  public List<Asset> queryAssetsByValueRange(HypernateContext ctx, int minValue, int maxValue) {
+    if (minValue > maxValue) throw new IllegalArgumentException("minValue must be <= maxValue");
+    try {
+      return ctx.getRegistry().query(Asset.class)
+          .where("value").between(minValue, maxValue)
+          .and("status").isNot(AssetStatus.ARCHIVED.name())
+          .sortBy("value", SortOrder.ASC)
+          .execute();
+    } catch (UncommittedStateException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Transaction
+  public List<Asset> listAssetsByOwner(HypernateContext ctx, String owner) {
+    return ctx.getRegistry().rangeQuery(Asset.class).withKeyPrefix(owner).execute();
+  }
+
+  @Transaction
+  public List<Asset> listAllAssets(HypernateContext ctx) {
+    return ctx.getRegistry().rangeQuery(Asset.class).fullScan().execute();
+  }
+
+  @Transaction
+  public Asset initiateTransfer(HypernateContext ctx, String assetId, String currentOwner, String newOwner, int agreedPrice) {
+    Registry registry = ctx.getRegistry();
+    Asset asset = registry.mustRead(Asset.class, currentOwner, assetId);
+    
+    if (asset.getStatus() != AssetStatus.ACTIVE) {
+      throw new RuntimeException(String.format("Asset %s is not in ACTIVE status; current status: %s. Only ACTIVE assets can be transferred.", assetId, asset.getStatus()));
+    }
+    if (!asset.getOwner().equals(currentOwner)) {
+      throw new RuntimeException(String.format("Owner mismatch: asset %s is owned by %s, not %s", assetId, asset.getOwner(), currentOwner));
+    }
+
+    PricingResponse pricing = ctx.invoke("PricingChaincode", "validatePrice")
+        .withArgs(new PricingRequest(assetId, asset.getValue(), newOwner, agreedPrice))
+        .returning(PricingResponse.class)
+        .execute();
+        
+    if (!pricing.valid()) {
+      throw new RuntimeException("Transfer rejected by PricingChaincode: " + pricing.notes());
+    }
+
+    asset.setStatus(AssetStatus.PENDING_TRANSFER);
+    registry.mustUpdate(asset);
+    return asset;
+  }
+
+  @Transaction
+  public Asset completeTransfer(HypernateContext ctx, String assetId, String currentOwner, String newOwner) {
+    Registry registry = ctx.getRegistry();
+    Asset asset = registry.mustRead(Asset.class, currentOwner, assetId);
+
+    if (asset.getStatus() != AssetStatus.PENDING_TRANSFER) {
+      throw new RuntimeException(String.format("Asset %s is not pending transfer; status: %s", assetId, asset.getStatus()));
+    }
+
+    asset.setOwner(newOwner);
+    asset.setStatus(AssetStatus.ACTIVE);
+    asset.setTimestamp(ctx.getStub().getTxTimestamp().toEpochMilli());
+    registry.mustUpdate(asset);
+    return asset;
+  }
+
+  @Transaction
+  public void archiveAsset(HypernateContext ctx, String owner, String id) {
+    Asset asset = ctx.getRegistry().mustRead(Asset.class, owner, id);
+    if (asset.getStatus() == AssetStatus.ARCHIVED) {
+      throw new RuntimeException("Asset " + id + " is already archived");
+    }
+    asset.setStatus(AssetStatus.ARCHIVED);
+    ctx.getRegistry().mustUpdate(asset);
+  }
+
+  @Transaction
+  public void setSensitiveAssetPolicy(HypernateContext ctx, String id, String owner, String expression) {
+    SensitiveAsset asset = ctx.getRegistry().mustRead(SensitiveAsset.class, owner, id);
+    EndorsementPolicy policy = EndorsementPolicy.of(expression);
+    ctx.getRegistry().setEndorsementPolicy(asset, policy);
+  }
+}
+
+@Contract(
+    name = "PricingChaincode",
+    info = @Info(title = "PricingChaincode", description = "Mock pricing chaincode", version = "1.0"))
+class PricingChaincode implements ContractInterface {
+
+  @Transaction
+  public String validatePrice(Context ctx, String pricingRequestJson) {
+    PricingRequest req;
+    try {
+      req = JSON.deserialize(pricingRequestJson, PricingRequest.class);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Invalid JSON for PricingRequest: " + e.getMessage(), e);
+    }
+    
+    if (req.currentValue() > 1000) {
+      boolean approved = req.offeredPrice() >= req.currentValue() * 0.9;
+      if (!approved) {
+        try {
+          return JSON.serialize(new PricingResponse(false, 0, 
+              String.format("Offered price %d is below 90%% of market value %d", req.offeredPrice(), req.currentValue())));
+        } catch (Exception e) { throw new RuntimeException(e); }
+      }
+    }
+    try {
+      return JSON.serialize(new PricingResponse(true, req.offeredPrice(), "Transfer approved at price " + req.offeredPrice()));
+    } catch (Exception e) { throw new RuntimeException(e); }
+  }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/SensitiveAsset.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/SensitiveAsset.java
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.sample;
+
+import hu.bme.mit.ftsrg.hypernate.annotations.AttributeInfo;
+import hu.bme.mit.ftsrg.hypernate.annotations.EndorsementPolicy;
+import hu.bme.mit.ftsrg.hypernate.annotations.PrimaryKey;
+
+@PrimaryKey({
+  @AttributeInfo(name = "owner"),
+  @AttributeInfo(name = "id")
+})
+@EndorsementPolicy("OR('Org1MSP.peer', 'Org2MSP.peer')")
+public class SensitiveAsset {
+  private String id;
+  private String color;
+  private int size;
+  private String owner;
+  private int value;
+
+  private long timestamp;
+  private AssetStatus status;
+  private String classLevel;
+  private java.util.List<String> orgs;
+
+  // Constructors
+  public SensitiveAsset() {}
+
+  public SensitiveAsset(String id, String color, int size, String owner, int value) {
+    this.id = id;
+    this.color = color;
+    this.size = size;
+    this.owner = owner;
+    this.value = value;
+  }
+
+  public SensitiveAsset(String id, String color, int size, String owner, int value, long timestamp, AssetStatus status, String classLevel, java.util.List<String> orgs) {
+    this.id = id;
+    this.color = color;
+    this.size = size;
+    this.owner = owner;
+    this.value = value;
+    this.timestamp = timestamp;
+    this.status = status;
+    this.classLevel = classLevel;
+    this.orgs = orgs;
+  }
+
+  // Getters and Setters
+  public String getId() { return id; }
+  public void setId(String id) { this.id = id; }
+  public String getColor() { return color; }
+  public void setColor(String color) { this.color = color; }
+  public int getSize() { return size; }
+  public void setSize(int size) { this.size = size; }
+  public String getOwner() { return owner; }
+  public void setOwner(String owner) { this.owner = owner; }
+  public int getValue() { return value; }
+  public void setValue(int value) { this.value = value; }
+  public long getTimestamp() { return timestamp; }
+  public void setTimestamp(long timestamp) { this.timestamp = timestamp; }
+  public AssetStatus getStatus() { return status; }
+  public void setStatus(AssetStatus status) { this.status = status; }
+  public String getClassLevel() { return classLevel; }
+  public void setClassLevel(String classLevel) { this.classLevel = classLevel; }
+  public java.util.List<String> getOrgs() { return orgs; }
+  public void setOrgs(java.util.List<String> orgs) { this.orgs = orgs; }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/SensitiveAsset.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/SensitiveAsset.java
@@ -5,10 +5,7 @@ import hu.bme.mit.ftsrg.hypernate.annotations.AttributeInfo;
 import hu.bme.mit.ftsrg.hypernate.annotations.EndorsementPolicy;
 import hu.bme.mit.ftsrg.hypernate.annotations.PrimaryKey;
 
-@PrimaryKey({
-  @AttributeInfo(name = "owner"),
-  @AttributeInfo(name = "id")
-})
+@PrimaryKey({@AttributeInfo(name = "owner"), @AttributeInfo(name = "id")})
 @EndorsementPolicy("OR('Org1MSP.peer', 'Org2MSP.peer')")
 public class SensitiveAsset {
   private String id;
@@ -33,7 +30,16 @@ public class SensitiveAsset {
     this.value = value;
   }
 
-  public SensitiveAsset(String id, String color, int size, String owner, int value, long timestamp, AssetStatus status, String classLevel, java.util.List<String> orgs) {
+  public SensitiveAsset(
+      String id,
+      String color,
+      int size,
+      String owner,
+      int value,
+      long timestamp,
+      AssetStatus status,
+      String classLevel,
+      java.util.List<String> orgs) {
     this.id = id;
     this.color = color;
     this.size = size;
@@ -46,22 +52,75 @@ public class SensitiveAsset {
   }
 
   // Getters and Setters
-  public String getId() { return id; }
-  public void setId(String id) { this.id = id; }
-  public String getColor() { return color; }
-  public void setColor(String color) { this.color = color; }
-  public int getSize() { return size; }
-  public void setSize(int size) { this.size = size; }
-  public String getOwner() { return owner; }
-  public void setOwner(String owner) { this.owner = owner; }
-  public int getValue() { return value; }
-  public void setValue(int value) { this.value = value; }
-  public long getTimestamp() { return timestamp; }
-  public void setTimestamp(long timestamp) { this.timestamp = timestamp; }
-  public AssetStatus getStatus() { return status; }
-  public void setStatus(AssetStatus status) { this.status = status; }
-  public String getClassLevel() { return classLevel; }
-  public void setClassLevel(String classLevel) { this.classLevel = classLevel; }
-  public java.util.List<String> getOrgs() { return orgs; }
-  public void setOrgs(java.util.List<String> orgs) { this.orgs = orgs; }
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getColor() {
+    return color;
+  }
+
+  public void setColor(String color) {
+    this.color = color;
+  }
+
+  public int getSize() {
+    return size;
+  }
+
+  public void setSize(int size) {
+    this.size = size;
+  }
+
+  public String getOwner() {
+    return owner;
+  }
+
+  public void setOwner(String owner) {
+    this.owner = owner;
+  }
+
+  public int getValue() {
+    return value;
+  }
+
+  public void setValue(int value) {
+    this.value = value;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(long timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public AssetStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(AssetStatus status) {
+    this.status = status;
+  }
+
+  public String getClassLevel() {
+    return classLevel;
+  }
+
+  public void setClassLevel(String classLevel) {
+    this.classLevel = classLevel;
+  }
+
+  public java.util.List<String> getOrgs() {
+    return orgs;
+  }
+
+  public void setOrgs(java.util.List<String> orgs) {
+    this.orgs = orgs;
+  }
 }

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/TransferRequest.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/TransferRequest.java
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.sample;
+
+public class TransferRequest {
+  private String assetId;
+  private String currentOwner;
+  private String newOwner;
+  private int agreedPrice;
+
+  public TransferRequest() {}
+
+  public TransferRequest(String assetId, String currentOwner, String newOwner, int agreedPrice) {
+    this.assetId = assetId;
+    this.currentOwner = currentOwner;
+    this.newOwner = newOwner;
+    this.agreedPrice = agreedPrice;
+  }
+
+  public String assetId() { return assetId; }
+  public String currentOwner() { return currentOwner; }
+  public String newOwner() { return newOwner; }
+  public int agreedPrice() { return agreedPrice; }
+  
+  public String getAssetId() { return assetId; }
+  public String getCurrentOwner() { return currentOwner; }
+  public String getNewOwner() { return newOwner; }
+  public int getAgreedPrice() { return agreedPrice; }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/TransferRequest.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/TransferRequest.java
@@ -16,13 +16,35 @@ public class TransferRequest {
     this.agreedPrice = agreedPrice;
   }
 
-  public String assetId() { return assetId; }
-  public String currentOwner() { return currentOwner; }
-  public String newOwner() { return newOwner; }
-  public int agreedPrice() { return agreedPrice; }
-  
-  public String getAssetId() { return assetId; }
-  public String getCurrentOwner() { return currentOwner; }
-  public String getNewOwner() { return newOwner; }
-  public int getAgreedPrice() { return agreedPrice; }
+  public String assetId() {
+    return assetId;
+  }
+
+  public String currentOwner() {
+    return currentOwner;
+  }
+
+  public String newOwner() {
+    return newOwner;
+  }
+
+  public int agreedPrice() {
+    return agreedPrice;
+  }
+
+  public String getAssetId() {
+    return assetId;
+  }
+
+  public String getCurrentOwner() {
+    return currentOwner;
+  }
+
+  public String getNewOwner() {
+    return newOwner;
+  }
+
+  public int getAgreedPrice() {
+    return agreedPrice;
+  }
 }

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/TransferResult.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/TransferResult.java
@@ -14,11 +14,27 @@ public class TransferResult {
     this.finalPrice = finalPrice;
   }
 
-  public boolean approved() { return approved; }
-  public String reason() { return reason; }
-  public int finalPrice() { return finalPrice; }
-  
-  public boolean isApproved() { return approved; }
-  public String getReason() { return reason; }
-  public int getFinalPrice() { return finalPrice; }
+  public boolean approved() {
+    return approved;
+  }
+
+  public String reason() {
+    return reason;
+  }
+
+  public int finalPrice() {
+    return finalPrice;
+  }
+
+  public boolean isApproved() {
+    return approved;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+
+  public int getFinalPrice() {
+    return finalPrice;
+  }
 }

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/TransferResult.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/sample/TransferResult.java
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.sample;
+
+public class TransferResult {
+  private boolean approved;
+  private String reason;
+  private int finalPrice;
+
+  public TransferResult() {}
+
+  public TransferResult(boolean approved, String reason, int finalPrice) {
+    this.approved = approved;
+    this.reason = reason;
+    this.finalPrice = finalPrice;
+  }
+
+  public boolean approved() { return approved; }
+  public String reason() { return reason; }
+  public int finalPrice() { return finalPrice; }
+  
+  public boolean isApproved() { return approved; }
+  public String getReason() { return reason; }
+  public int getFinalPrice() { return finalPrice; }
+}

--- a/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/PrototypeTests.java
+++ b/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/PrototypeTests.java
@@ -1,0 +1,555 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import hu.bme.mit.ftsrg.hypernate.context.CrossChaincodeException;
+import hu.bme.mit.ftsrg.hypernate.context.HypernateContext;
+import hu.bme.mit.ftsrg.hypernate.endorsement.EndorsementPolicy;
+import hu.bme.mit.ftsrg.hypernate.endorsement.InvalidEndorsementPolicyException;
+import hu.bme.mit.ftsrg.hypernate.middleware.StubMiddlewareChain;
+import hu.bme.mit.ftsrg.hypernate.middleware.WriteBackCachedStubMiddleware;
+import hu.bme.mit.ftsrg.hypernate.registry.Registry;
+import hu.bme.mit.ftsrg.hypernate.registry.EntityNotFoundException;
+import hu.bme.mit.ftsrg.hypernate.registry.SortOrder;
+import hu.bme.mit.ftsrg.hypernate.registry.query.InvalidRangeQueryException;
+import hu.bme.mit.ftsrg.hypernate.registry.query.UncommittedStateException;
+import hu.bme.mit.ftsrg.hypernate.sample.Asset;
+import hu.bme.mit.ftsrg.hypernate.sample.AssetStatus;
+import hu.bme.mit.ftsrg.hypernate.sample.PricingResponse;
+import hu.bme.mit.ftsrg.hypernate.sample.SampleChaincode;
+import hu.bme.mit.ftsrg.hypernate.sample.SensitiveAsset;
+import hu.bme.mit.ftsrg.hypernate.sample.TransferResult;
+import hu.bme.mit.ftsrg.hypernate.util.JSON;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import org.hyperledger.fabric.shim.Chaincode.Response;
+import org.hyperledger.fabric.shim.ChaincodeStub;
+import org.hyperledger.fabric.shim.ledger.CompositeKey;
+import org.hyperledger.fabric.shim.ledger.KeyValue;
+import org.hyperledger.fabric.shim.ledger.QueryResultsIterator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@org.mockito.junit.jupiter.MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
+public class PrototypeTests {
+
+  @Test
+  public void testQueryBuilderSelector_SingleCondition() throws Exception {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    Registry registry = new Registry(fabricStub);
+    ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
+    QueryResultsIterator<KeyValue> iter = mock(QueryResultsIterator.class);
+    when(iter.iterator()).thenReturn(Collections.emptyIterator());
+    when(fabricStub.getQueryResult(queryCaptor.capture())).thenReturn(iter);
+
+    registry.query(Asset.class).where("color").is("blue").execute();
+    
+    String json = queryCaptor.getValue();
+    assertThat(json).contains("\"color\":\"blue\"");
+    assertThat(json).contains("\"docType\":\"HU.BME.MIT.FTSRG.HYPERNATE.SAMPLE.ASSET\"");
+  }
+
+  @Test
+  public void testQueryBuilderSelector_MultiCondition() throws Exception {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    Registry registry = new Registry(fabricStub);
+    ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
+    QueryResultsIterator<KeyValue> iter = mock(QueryResultsIterator.class);
+    when(iter.iterator()).thenReturn(Collections.emptyIterator());
+    when(fabricStub.getQueryResult(queryCaptor.capture())).thenReturn(iter);
+
+    registry.query(Asset.class).where("color").is("blue").and("size").greaterThan(10).execute();
+    
+    String json = queryCaptor.getValue();
+    assertThat(json).contains("\"color\":\"blue\"");
+    assertThat(json).contains("\"size\":{\"$gt\":10}");
+  }
+
+  @Test
+  public void testQueryBuilderSelector_Between() throws Exception {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    Registry registry = new Registry(fabricStub);
+    ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
+    QueryResultsIterator<KeyValue> iter = mock(QueryResultsIterator.class);
+    when(iter.iterator()).thenReturn(Collections.emptyIterator());
+    when(fabricStub.getQueryResult(queryCaptor.capture())).thenReturn(iter);
+
+    registry.query(Asset.class).where("value").between(100, 500).execute();
+    
+    String json = queryCaptor.getValue();
+    assertThat(json).contains("\"$gte\":100");
+    assertThat(json).contains("\"$lte\":500");
+  }
+
+  @Test
+  public void testQueryBuilderSelector_In() throws Exception {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    Registry registry = new Registry(fabricStub);
+    ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
+    QueryResultsIterator<KeyValue> iter = mock(QueryResultsIterator.class);
+    when(iter.iterator()).thenReturn(Collections.emptyIterator());
+    when(fabricStub.getQueryResult(queryCaptor.capture())).thenReturn(iter);
+
+    registry.query(Asset.class).and("owner").in("Alice", "Bob").execute();
+    assertThat(queryCaptor.getValue()).contains("\"$in\":[\"Alice\",\"Bob\"]");
+  }
+
+  @Test
+  public void testQueryBuilderSelector_SortBy() throws Exception {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    Registry registry = new Registry(fabricStub);
+    ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
+    QueryResultsIterator<KeyValue> iter = mock(QueryResultsIterator.class);
+    when(iter.iterator()).thenReturn(Collections.emptyIterator());
+    when(fabricStub.getQueryResult(queryCaptor.capture())).thenReturn(iter);
+
+    registry.query(Asset.class).sortBy("value", SortOrder.DESC).sortBy("color", SortOrder.ASC).execute();
+    assertThat(queryCaptor.getValue()).contains("\"sort\":[{\"value\":\"desc\"},{\"color\":\"asc\"}]");
+  }
+
+  @Test
+  public void testQueryBuilderSelector_UseIndex() throws Exception {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    Registry registry = new Registry(fabricStub);
+    ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
+    QueryResultsIterator<KeyValue> iter = mock(QueryResultsIterator.class);
+    when(iter.iterator()).thenReturn(Collections.emptyIterator());
+    when(fabricStub.getQueryResult(queryCaptor.capture())).thenReturn(iter);
+
+    registry.query(Asset.class).useIndex("designDocName", "indexName").execute();
+    assertThat(queryCaptor.getValue()).contains("\"use_index\":[\"designDocName\",\"indexName\"]");
+  }
+
+  @Test
+  public void testQueryBuilderSelector_LimitSkip() throws Exception {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    Registry registry = new Registry(fabricStub);
+    ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
+    QueryResultsIterator<KeyValue> iter = mock(QueryResultsIterator.class);
+    when(iter.iterator()).thenReturn(Collections.emptyIterator());
+    when(fabricStub.getQueryResult(queryCaptor.capture())).thenReturn(iter);
+
+    registry.query(Asset.class).limit(50).skip(10).execute();
+    String json = queryCaptor.getValue();
+    assertThat(json).contains("\"limit\":50");
+    assertThat(json).contains("\"skip\":10");
+  }
+
+  @Test
+  public void testQueryBuilderSelector_DocTypeAutoFilter() throws Exception {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    Registry registry = new Registry(fabricStub);
+    ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
+    QueryResultsIterator<KeyValue> iter = mock(QueryResultsIterator.class);
+    when(iter.iterator()).thenReturn(Collections.emptyIterator());
+    when(fabricStub.getQueryResult(queryCaptor.capture())).thenReturn(iter);
+
+    registry.query(Asset.class).execute();
+    assertThat(queryCaptor.getValue()).contains("\"docType\":\"HU.BME.MIT.FTSRG.HYPERNATE.SAMPLE.ASSET\"");
+  }
+
+  @Test
+  public void testUncommittedStateException_ThrowsWhenDirty() {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    StubMiddlewareChain chain = StubMiddlewareChain.builder(fabricStub)
+        .push(WriteBackCachedStubMiddleware.class).build();
+    WriteBackCachedStubMiddleware mw = (WriteBackCachedStubMiddleware) chain.getFirst();
+    mw.putState("k", "v".getBytes());
+    
+    Registry registry = new Registry(chain.getFirst());
+    assertThatThrownBy(() -> registry.query(Asset.class).where("color").is("x").execute())
+      .isInstanceOf(UncommittedStateException.class)
+      .hasMessageContaining("uncommitted writes exist in the middleware cache")
+      .hasMessageContaining("invisible to getQueryResult")
+      .hasMessageContaining("TransactionEnd");
+  }
+
+  @Test
+  public void testUncommittedStateException_CleanCache() throws Exception {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    StubMiddlewareChain chain = StubMiddlewareChain.builder(fabricStub)
+        .push(WriteBackCachedStubMiddleware.class).build();
+    Registry registry = new Registry(chain.getFirst());
+
+    QueryResultsIterator<KeyValue> iter = mock(QueryResultsIterator.class);
+    when(iter.iterator()).thenReturn(Collections.emptyIterator());
+    when(fabricStub.getQueryResult(anyString())).thenReturn(iter);
+
+    registry.query(Asset.class).where("color").is("x").execute();
+  }
+
+  @Test
+  public void testUncommittedStateException_NoMiddleware() throws Exception {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    Registry registry = new Registry(fabricStub);
+
+    QueryResultsIterator<KeyValue> iter = mock(QueryResultsIterator.class);
+    when(iter.iterator()).thenReturn(Collections.emptyIterator());
+    when(fabricStub.getQueryResult(anyString())).thenReturn(iter);
+
+    registry.query(Asset.class).where("color").is("x").execute();
+  }
+
+  public static class NoPKEntity { public String id; }
+
+  @Test
+  public void testRangeQueryGuard_NoPK() {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    Registry registry = new Registry(fabricStub);
+    assertThatThrownBy(() -> registry.rangeQuery(NoPKEntity.class).withKeyPrefix("x"))
+      .isInstanceOf(InvalidRangeQueryException.class)
+      .hasMessageContaining("no @PrimaryKey annotation found");
+  }
+
+  @Test
+  public void testRangeQueryGuard_TooManyPrefixParts() {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    Registry registry = new Registry(fabricStub);
+    assertThatThrownBy(() -> registry.rangeQuery(Asset.class).withKeyPrefix("a", "b", "c"))
+      .isInstanceOf(InvalidRangeQueryException.class)
+      .hasMessageContaining("Too many prefix parts");
+  }
+
+  @Test
+  public void testRangeQueryGuard_NullPrefix() {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    Registry registry = new Registry(fabricStub);
+    assertThatThrownBy(() -> registry.rangeQuery(Asset.class).withKeyPrefix("Alice", null))
+      .isInstanceOf(InvalidRangeQueryException.class)
+      .hasMessageContaining("Null prefix component at index 1");
+  }
+
+  @Test
+  public void testRangeQueryGuard_FullScan() throws Exception {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    when(fabricStub.createCompositeKey(anyString(), any(String[].class))).thenReturn(new CompositeKey("test"));
+    Registry registry = new Registry(fabricStub);
+
+    QueryResultsIterator<KeyValue> iter = mock(QueryResultsIterator.class);
+    when(iter.iterator()).thenReturn(Collections.emptyIterator());
+    when(fabricStub.getStateByPartialCompositeKey(any(CompositeKey.class))).thenReturn(iter);
+
+    List<Asset> result = registry.rangeQuery(Asset.class).fullScan().execute();
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void testRangeQueryGuard_ExecuteWithoutConfig() {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    Registry registry = new Registry(fabricStub);
+    assertThatThrownBy(() -> registry.rangeQuery(Asset.class).execute())
+      .isInstanceOf(InvalidRangeQueryException.class)
+      .hasMessageContaining("Configure the query before executing");
+  }
+
+  @Test
+  public void testCrossChaincode_Success() throws Exception {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    HypernateContext ctx = mock(HypernateContext.class);
+    when(ctx.getStub()).thenReturn(fabricStub);
+    when(ctx.getFabricStub()).thenReturn(fabricStub);
+    when(ctx.invoke(anyString(), anyString())).thenCallRealMethod();
+    
+    Response resp = mock(Response.class);
+    when(resp.getStatus()).thenReturn(Response.Status.SUCCESS);
+    when(resp.getStringPayload()).thenReturn(JSON.serialize(new TransferResult(true, "OK", 100)));
+    when(fabricStub.invokeChaincode(eq("cc"), org.mockito.ArgumentMatchers.<List<byte[]>>any())).thenReturn(resp);
+
+    TransferResult res = ctx.invoke("cc", "fn").returning(TransferResult.class).execute();
+    assertThat(res.approved()).isTrue();
+  }
+
+  @Test
+  public void testCrossChaincode_ErrorPropagation() {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    HypernateContext ctx = mock(HypernateContext.class);
+    when(ctx.getStub()).thenReturn(fabricStub);
+    when(ctx.getFabricStub()).thenReturn(fabricStub);
+    when(ctx.invoke(anyString(), anyString())).thenCallRealMethod();
+
+    Response resp = mock(Response.class);
+    when(resp.getStatus()).thenReturn(Response.Status.INTERNAL_SERVER_ERROR);
+    when(resp.getMessage()).thenReturn("chaincode panicked");
+    when(fabricStub.invokeChaincode(eq("testCC"), org.mockito.ArgumentMatchers.<List<byte[]>>any())).thenReturn(resp);
+
+    assertThatThrownBy(() -> ctx.invoke("testCC", "doWork").returningVoid().execute())
+      .isInstanceOf(CrossChaincodeException.class)
+      .satisfies(e -> {
+        CrossChaincodeException ex = (CrossChaincodeException) e;
+        assertThat(ex.getChaincodeId()).isEqualTo("testCC");
+        assertThat(ex.getFunctionName()).isEqualTo("doWork");
+        assertThat(ex.getStatusCode()).isEqualTo(500);
+        assertThat(ex.getOriginalMessage()).isEqualTo("chaincode panicked");
+      });
+  }
+
+  @Test
+  public void testCrossChaincode_ReturningVoid() {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    HypernateContext ctx = mock(HypernateContext.class);
+    when(ctx.getStub()).thenReturn(fabricStub);
+    when(ctx.getFabricStub()).thenReturn(fabricStub);
+    when(ctx.invoke(anyString(), anyString())).thenCallRealMethod();
+
+    Response resp = mock(Response.class);
+    when(resp.getStatus()).thenReturn(Response.Status.SUCCESS);
+    when(fabricStub.invokeChaincode(eq("cc"), org.mockito.ArgumentMatchers.<List<byte[]>>any())).thenReturn(resp);
+
+    Void res = ctx.invoke("cc", "fn").returningVoid().execute();
+    assertThat(res).isNull();
+    verify(resp, never()).getStringPayload();
+  }
+
+  @Test
+  public void testCrossChaincode_NoReturnConfig() {
+    HypernateContext ctx = mock(HypernateContext.class);
+    ChaincodeStub dummyStub = mock(ChaincodeStub.class);
+    when(ctx.getStub()).thenReturn(dummyStub);
+    when(ctx.getFabricStub()).thenReturn(dummyStub);
+    when(ctx.invoke(anyString(), anyString())).thenCallRealMethod();
+    assertThatThrownBy(() -> ctx.invoke("cc", "fn").execute())
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("returning(Class) or .returningVoid()");
+  }
+
+  @Test
+  public void testCrossChaincode_MixedArgs() {
+    HypernateContext ctx = mock(HypernateContext.class);
+    when(ctx.invoke(anyString(), anyString())).thenCallRealMethod();
+    assertThatThrownBy(() -> ctx.invoke("cc", "fn").withArgs("x").withRawArgs("y".getBytes()).returningVoid().execute())
+      .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void testEndorsementPolicyValidation_Valid() {
+    EndorsementPolicy.of("OR('Org1MSP.peer', 'Org2MSP.peer')");
+    EndorsementPolicy.of("AND('Org1MSP.member', 'Org2MSP.member')");
+    EndorsementPolicy.of("OutOf(2, 'Org1MSP.peer', 'Org2MSP.peer', 'Org3MSP.peer')");
+  }
+
+  @Test
+  public void testEndorsementPolicyValidation_Unbalanced1() {
+    assertThatThrownBy(() -> EndorsementPolicy.of("OR('Org1MSP.peer'"))
+      .isInstanceOf(InvalidEndorsementPolicyException.class)
+      .hasMessageContaining("Unclosed parenthesis");
+  }
+
+  @Test
+  public void testEndorsementPolicyValidation_Unbalanced2() {
+    assertThatThrownBy(() -> EndorsementPolicy.of(")OR('Org1MSP.peer')"))
+      .isInstanceOf(InvalidEndorsementPolicyException.class)
+      .hasMessageContaining("Unexpected closing parenthesis");
+  }
+
+  @Test
+  public void testEndorsementPolicyValidation_UnsupportedFunction() {
+    assertThatThrownBy(() -> EndorsementPolicy.of("XOR('Org1MSP.peer')"))
+      .isInstanceOf(InvalidEndorsementPolicyException.class)
+      .hasMessageContaining("Unsupported policy function 'XOR'");
+  }
+
+  @Test
+  public void testEndorsementPolicyValidation_InvalidMSPFormat() {
+    assertThatThrownBy(() -> EndorsementPolicy.of("OR('Org1.peer')"))
+      .isInstanceOf(InvalidEndorsementPolicyException.class)
+      .hasMessageContaining("Invalid MSP principal");
+  }
+
+  @Test
+  public void testEndorsementPolicyValidation_InvalidRole() {
+    assertThatThrownBy(() -> EndorsementPolicy.of("OR('Org1MSP.validator')"))
+      .isInstanceOf(InvalidEndorsementPolicyException.class)
+      .hasMessageContaining("Invalid MSP principal");
+  }
+
+  @Test
+  public void testEndorsementPolicyValidation_Empty() {
+    assertThatThrownBy(() -> EndorsementPolicy.of(""))
+      .isInstanceOf(InvalidEndorsementPolicyException.class);
+  }
+
+  @Test
+  public void testEndorsementPolicyValidation_OutOfArg() {
+    assertThatThrownBy(() -> EndorsementPolicy.of("OutOf(two, 'Org1MSP.peer')"))
+      .isInstanceOf(InvalidEndorsementPolicyException.class)
+      .hasMessageContaining("integer as its first argument");
+  }
+
+  @Test
+  public void testEndorsementPolicyBuilder_AND() {
+    EndorsementPolicy built = EndorsementPolicy.builder().and().org("Org1").peer().org("Org2").peer().build();
+    assertThat(built.getExpression()).isEqualTo("AND('Org1MSP.peer', 'Org2MSP.peer')");
+  }
+
+  @Test
+  public void testEndorsementPolicyBuilder_OutOf() {
+    EndorsementPolicy built = EndorsementPolicy.builder().outOf(2).org("Org1").peer().org("Org2").peer().org("Org3").peer().build();
+    assertThat(built.getExpression()).isEqualTo("OutOf(2, 'Org1MSP.peer', 'Org2MSP.peer', 'Org3MSP.peer')");
+  }
+
+  @Test
+  public void testEndorsementPolicyBuilder_EqualsDirect() {
+    String expr = "OR('Org1MSP.peer', 'Org2MSP.peer')";
+    EndorsementPolicy direct = EndorsementPolicy.of(expr);
+    EndorsementPolicy built = EndorsementPolicy.builder().or().org("Org1").peer().org("Org2").peer().build();
+    assertThat(direct.getExpression()).isEqualTo(built.getExpression());
+  }
+
+  @Test
+  public void testEndorsementPolicyBuilder_Empty() {
+    assertThatThrownBy(() -> EndorsementPolicy.builder().build()).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void testEndorsementPolicyBuilder_ExceedsThreshold() {
+    assertThatThrownBy(() -> EndorsementPolicy.builder().outOf(3).org("Org1").peer().build())
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("exceeds number of principals");
+  }
+
+  @Test
+  public void testRegistryEndorsement_mustCreateSensitive() throws Exception {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    when(fabricStub.createCompositeKey(anyString(), any(String[].class))).thenReturn(new CompositeKey("mock"));
+    when(fabricStub.getState(anyString())).thenReturn(null);
+    Registry registry = new Registry(fabricStub);
+
+    SensitiveAsset sensitiveAsset = new SensitiveAsset("id", "red", 1, "owner", 10, 0, AssetStatus.ACTIVE, "A", Collections.emptyList());
+    registry.mustCreate(sensitiveAsset);
+
+    verify(fabricStub).setStateValidationParameter(anyString(), any(byte[].class));
+  }
+
+  @Test
+  public void testRegistryEndorsement_mustCreateNormal() throws Exception {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    when(fabricStub.createCompositeKey(anyString(), any(String[].class))).thenReturn(new CompositeKey("mock"));
+    when(fabricStub.getState(anyString())).thenReturn(null);
+    Registry registry = new Registry(fabricStub);
+
+    Asset asset = new Asset("id", "red", 1, "owner", 10, 0, AssetStatus.ACTIVE);
+    registry.mustCreate(asset);
+
+    verify(fabricStub, never()).setStateValidationParameter(anyString(), any(byte[].class));
+  }
+
+  @Test
+  public void testRegistryEndorsement_setEndorsementPolicyNotFound() {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    when(fabricStub.createCompositeKey(anyString(), any(String[].class))).thenReturn(new CompositeKey("mock"));
+    when(fabricStub.getState(anyString())).thenReturn(new byte[0]);
+    Registry registry = new Registry(fabricStub);
+    
+    Asset asset = new Asset("id", "red", 1, "owner", 10);
+    EndorsementPolicy pol = EndorsementPolicy.of("OR('Org1MSP.peer')");
+    
+    assertThatThrownBy(() -> registry.setEndorsementPolicy(asset, pol))
+      .isInstanceOf(EntityNotFoundException.class)
+      .hasMessageContaining("Cannot set endorsement policy: entity does not exist");
+  }
+
+  @Test
+  public void testSampleChaincode_createAssetBlankId() {
+    SampleChaincode sc = new SampleChaincode();
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    org.hyperledger.fabric.shim.ext.sbe.StateBasedEndorsement sbe = mock(org.hyperledger.fabric.shim.ext.sbe.StateBasedEndorsement.class);
+    when(fabricStub.getTxTimestamp()).thenReturn(java.time.Instant.now());
+    HypernateContext ctx = mock(HypernateContext.class);
+    when(ctx.getStub()).thenReturn(fabricStub);
+    when(ctx.getFabricStub()).thenReturn(fabricStub);
+    when(ctx.getRegistry()).thenReturn(new Registry(fabricStub));
+    assertThatThrownBy(() -> sc.createAsset(ctx, "", "red", 10, "Alice", 100))
+      .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("id");
+  }
+
+  @Test
+  public void testSampleChaincode_createAssetNegativeSize() {
+    SampleChaincode sc = new SampleChaincode();
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    when(fabricStub.getTxTimestamp()).thenReturn(java.time.Instant.now());
+    HypernateContext ctx = mock(HypernateContext.class);
+    when(ctx.getStub()).thenReturn(fabricStub);
+    when(ctx.getFabricStub()).thenReturn(fabricStub);
+    when(ctx.getRegistry()).thenReturn(new Registry(fabricStub));
+    assertThatThrownBy(() -> sc.createAsset(ctx, "a1", "red", -1, "Alice", 100))
+      .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("size");
+  }
+
+  @Test
+  public void testSampleChaincode_initiateTransferArchived() throws Exception {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    when(fabricStub.createCompositeKey(anyString(), any(String[].class))).thenReturn(new CompositeKey("mock"));
+    Asset archived = new Asset("id", "red", 1, "owner", 10, 0, AssetStatus.ARCHIVED);
+    when(fabricStub.getState(anyString())).thenReturn(JSON.serialize(archived).getBytes());
+    
+    SampleChaincode sc = new SampleChaincode();
+    HypernateContext ctx = mock(HypernateContext.class);
+    when(ctx.getRegistry()).thenReturn(new Registry(fabricStub));
+    when(ctx.getStub()).thenReturn(fabricStub);
+    when(ctx.getFabricStub()).thenReturn(fabricStub);
+    when(ctx.invoke(anyString(), anyString())).thenCallRealMethod();
+
+    assertThatThrownBy(() -> sc.initiateTransfer(ctx, "id", "owner", "new", 10))
+      .isInstanceOf(RuntimeException.class).hasMessageContaining("not in ACTIVE status");
+  }
+
+  @Test
+  public void testSampleChaincode_initiateTransferRejected() throws Exception {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    when(fabricStub.createCompositeKey(anyString(), any(String[].class))).thenReturn(new CompositeKey("mock"));
+    Asset active = new Asset("id", "red", 1, "owner", 10, 0, AssetStatus.ACTIVE);
+    when(fabricStub.getState(anyString())).thenReturn(JSON.serialize(active).getBytes());
+    
+    Response resp = mock(Response.class);
+    when(resp.getStatus()).thenReturn(Response.Status.SUCCESS);
+    when(resp.getStringPayload()).thenReturn(JSON.serialize(new PricingResponse(false, 0, "Too low")));
+    when(fabricStub.invokeChaincode(eq("PricingChaincode"), org.mockito.ArgumentMatchers.<List<byte[]>>any())).thenReturn(resp);
+
+    SampleChaincode sc = new SampleChaincode();
+    HypernateContext ctx = mock(HypernateContext.class);
+    when(ctx.getRegistry()).thenReturn(new Registry(fabricStub));
+    when(ctx.getStub()).thenReturn(fabricStub);
+    when(ctx.getFabricStub()).thenReturn(fabricStub);
+    when(ctx.invoke(anyString(), anyString())).thenCallRealMethod();
+
+    assertThatThrownBy(() -> sc.initiateTransfer(ctx, "id", "owner", "new", 10))
+      .isInstanceOf(RuntimeException.class).hasMessageContaining("Transfer rejected");
+  }
+
+  @Test
+  public void testSampleChaincode_initiateTransferSuccess() throws Exception {
+    ChaincodeStub fabricStub = mock(ChaincodeStub.class);
+    when(fabricStub.createCompositeKey(anyString(), any(String[].class))).thenReturn(new CompositeKey("mock"));
+    Asset active = new Asset("id", "red", 1, "owner", 10, 0, AssetStatus.ACTIVE);
+    when(fabricStub.getState(anyString())).thenReturn(JSON.serialize(active).getBytes());
+    
+    Response resp = mock(Response.class);
+    when(resp.getStatus()).thenReturn(Response.Status.SUCCESS);
+    when(resp.getStringPayload()).thenReturn(JSON.serialize(new PricingResponse(true, 50, "OK")));
+    when(fabricStub.invokeChaincode(eq("PricingChaincode"), org.mockito.ArgumentMatchers.<List<byte[]>>any())).thenReturn(resp);
+
+    SampleChaincode sc = new SampleChaincode();
+    HypernateContext ctx = mock(HypernateContext.class);
+    when(ctx.getRegistry()).thenReturn(new Registry(fabricStub));
+    when(ctx.getStub()).thenReturn(fabricStub);
+    when(ctx.getFabricStub()).thenReturn(fabricStub);
+    when(ctx.invoke(anyString(), anyString())).thenCallRealMethod();
+
+    Asset result = sc.initiateTransfer(ctx, "id", "owner", "new", 50);
+    assertThat(result.getStatus()).isEqualTo(AssetStatus.PENDING_TRANSFER);
+    verify(fabricStub).putState(anyString(), any(byte[].class)); // Must update
+  }
+}

--- a/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/PrototypeTests.java
+++ b/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/PrototypeTests.java
@@ -17,8 +17,8 @@ import hu.bme.mit.ftsrg.hypernate.endorsement.EndorsementPolicy;
 import hu.bme.mit.ftsrg.hypernate.endorsement.InvalidEndorsementPolicyException;
 import hu.bme.mit.ftsrg.hypernate.middleware.StubMiddlewareChain;
 import hu.bme.mit.ftsrg.hypernate.middleware.WriteBackCachedStubMiddleware;
-import hu.bme.mit.ftsrg.hypernate.registry.Registry;
 import hu.bme.mit.ftsrg.hypernate.registry.EntityNotFoundException;
+import hu.bme.mit.ftsrg.hypernate.registry.Registry;
 import hu.bme.mit.ftsrg.hypernate.registry.SortOrder;
 import hu.bme.mit.ftsrg.hypernate.registry.query.InvalidRangeQueryException;
 import hu.bme.mit.ftsrg.hypernate.registry.query.UncommittedStateException;
@@ -29,7 +29,6 @@ import hu.bme.mit.ftsrg.hypernate.sample.SampleChaincode;
 import hu.bme.mit.ftsrg.hypernate.sample.SensitiveAsset;
 import hu.bme.mit.ftsrg.hypernate.sample.TransferResult;
 import hu.bme.mit.ftsrg.hypernate.util.JSON;
-import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import org.hyperledger.fabric.shim.Chaincode.Response;
@@ -56,7 +55,7 @@ public class PrototypeTests {
     when(fabricStub.getQueryResult(queryCaptor.capture())).thenReturn(iter);
 
     registry.query(Asset.class).where("color").is("blue").execute();
-    
+
     String json = queryCaptor.getValue();
     assertThat(json).contains("\"color\":\"blue\"");
     assertThat(json).contains("\"docType\":\"HU.BME.MIT.FTSRG.HYPERNATE.SAMPLE.ASSET\"");
@@ -72,7 +71,7 @@ public class PrototypeTests {
     when(fabricStub.getQueryResult(queryCaptor.capture())).thenReturn(iter);
 
     registry.query(Asset.class).where("color").is("blue").and("size").greaterThan(10).execute();
-    
+
     String json = queryCaptor.getValue();
     assertThat(json).contains("\"color\":\"blue\"");
     assertThat(json).contains("\"size\":{\"$gt\":10}");
@@ -88,7 +87,7 @@ public class PrototypeTests {
     when(fabricStub.getQueryResult(queryCaptor.capture())).thenReturn(iter);
 
     registry.query(Asset.class).where("value").between(100, 500).execute();
-    
+
     String json = queryCaptor.getValue();
     assertThat(json).contains("\"$gte\":100");
     assertThat(json).contains("\"$lte\":500");
@@ -116,8 +115,13 @@ public class PrototypeTests {
     when(iter.iterator()).thenReturn(Collections.emptyIterator());
     when(fabricStub.getQueryResult(queryCaptor.capture())).thenReturn(iter);
 
-    registry.query(Asset.class).sortBy("value", SortOrder.DESC).sortBy("color", SortOrder.ASC).execute();
-    assertThat(queryCaptor.getValue()).contains("\"sort\":[{\"value\":\"desc\"},{\"color\":\"asc\"}]");
+    registry
+        .query(Asset.class)
+        .sortBy("value", SortOrder.DESC)
+        .sortBy("color", SortOrder.ASC)
+        .execute();
+    assertThat(queryCaptor.getValue())
+        .contains("\"sort\":[{\"value\":\"desc\"},{\"color\":\"asc\"}]");
   }
 
   @Test
@@ -158,30 +162,31 @@ public class PrototypeTests {
     when(fabricStub.getQueryResult(queryCaptor.capture())).thenReturn(iter);
 
     registry.query(Asset.class).execute();
-    assertThat(queryCaptor.getValue()).contains("\"docType\":\"HU.BME.MIT.FTSRG.HYPERNATE.SAMPLE.ASSET\"");
+    assertThat(queryCaptor.getValue())
+        .contains("\"docType\":\"HU.BME.MIT.FTSRG.HYPERNATE.SAMPLE.ASSET\"");
   }
 
   @Test
   public void testUncommittedStateException_ThrowsWhenDirty() {
     ChaincodeStub fabricStub = mock(ChaincodeStub.class);
-    StubMiddlewareChain chain = StubMiddlewareChain.builder(fabricStub)
-        .push(WriteBackCachedStubMiddleware.class).build();
+    StubMiddlewareChain chain =
+        StubMiddlewareChain.builder(fabricStub).push(WriteBackCachedStubMiddleware.class).build();
     WriteBackCachedStubMiddleware mw = (WriteBackCachedStubMiddleware) chain.getFirst();
     mw.putState("k", "v".getBytes());
-    
+
     Registry registry = new Registry(chain.getFirst());
     assertThatThrownBy(() -> registry.query(Asset.class).where("color").is("x").execute())
-      .isInstanceOf(UncommittedStateException.class)
-      .hasMessageContaining("uncommitted writes exist in the middleware cache")
-      .hasMessageContaining("invisible to getQueryResult")
-      .hasMessageContaining("TransactionEnd");
+        .isInstanceOf(UncommittedStateException.class)
+        .hasMessageContaining("uncommitted writes exist in the middleware cache")
+        .hasMessageContaining("invisible to getQueryResult")
+        .hasMessageContaining("TransactionEnd");
   }
 
   @Test
   public void testUncommittedStateException_CleanCache() throws Exception {
     ChaincodeStub fabricStub = mock(ChaincodeStub.class);
-    StubMiddlewareChain chain = StubMiddlewareChain.builder(fabricStub)
-        .push(WriteBackCachedStubMiddleware.class).build();
+    StubMiddlewareChain chain =
+        StubMiddlewareChain.builder(fabricStub).push(WriteBackCachedStubMiddleware.class).build();
     Registry registry = new Registry(chain.getFirst());
 
     QueryResultsIterator<KeyValue> iter = mock(QueryResultsIterator.class);
@@ -203,15 +208,17 @@ public class PrototypeTests {
     registry.query(Asset.class).where("color").is("x").execute();
   }
 
-  public static class NoPKEntity { public String id; }
+  public static class NoPKEntity {
+    public String id;
+  }
 
   @Test
   public void testRangeQueryGuard_NoPK() {
     ChaincodeStub fabricStub = mock(ChaincodeStub.class);
     Registry registry = new Registry(fabricStub);
     assertThatThrownBy(() -> registry.rangeQuery(NoPKEntity.class).withKeyPrefix("x"))
-      .isInstanceOf(InvalidRangeQueryException.class)
-      .hasMessageContaining("no @PrimaryKey annotation found");
+        .isInstanceOf(InvalidRangeQueryException.class)
+        .hasMessageContaining("no @PrimaryKey annotation found");
   }
 
   @Test
@@ -219,8 +226,8 @@ public class PrototypeTests {
     ChaincodeStub fabricStub = mock(ChaincodeStub.class);
     Registry registry = new Registry(fabricStub);
     assertThatThrownBy(() -> registry.rangeQuery(Asset.class).withKeyPrefix("a", "b", "c"))
-      .isInstanceOf(InvalidRangeQueryException.class)
-      .hasMessageContaining("Too many prefix parts");
+        .isInstanceOf(InvalidRangeQueryException.class)
+        .hasMessageContaining("Too many prefix parts");
   }
 
   @Test
@@ -228,14 +235,15 @@ public class PrototypeTests {
     ChaincodeStub fabricStub = mock(ChaincodeStub.class);
     Registry registry = new Registry(fabricStub);
     assertThatThrownBy(() -> registry.rangeQuery(Asset.class).withKeyPrefix("Alice", null))
-      .isInstanceOf(InvalidRangeQueryException.class)
-      .hasMessageContaining("Null prefix component at index 1");
+        .isInstanceOf(InvalidRangeQueryException.class)
+        .hasMessageContaining("Null prefix component at index 1");
   }
 
   @Test
   public void testRangeQueryGuard_FullScan() throws Exception {
     ChaincodeStub fabricStub = mock(ChaincodeStub.class);
-    when(fabricStub.createCompositeKey(anyString(), any(String[].class))).thenReturn(new CompositeKey("test"));
+    when(fabricStub.createCompositeKey(anyString(), any(String[].class)))
+        .thenReturn(new CompositeKey("test"));
     Registry registry = new Registry(fabricStub);
 
     QueryResultsIterator<KeyValue> iter = mock(QueryResultsIterator.class);
@@ -251,8 +259,8 @@ public class PrototypeTests {
     ChaincodeStub fabricStub = mock(ChaincodeStub.class);
     Registry registry = new Registry(fabricStub);
     assertThatThrownBy(() -> registry.rangeQuery(Asset.class).execute())
-      .isInstanceOf(InvalidRangeQueryException.class)
-      .hasMessageContaining("Configure the query before executing");
+        .isInstanceOf(InvalidRangeQueryException.class)
+        .hasMessageContaining("Configure the query before executing");
   }
 
   @Test
@@ -262,11 +270,12 @@ public class PrototypeTests {
     when(ctx.getStub()).thenReturn(fabricStub);
     when(ctx.getFabricStub()).thenReturn(fabricStub);
     when(ctx.invoke(anyString(), anyString())).thenCallRealMethod();
-    
+
     Response resp = mock(Response.class);
     when(resp.getStatus()).thenReturn(Response.Status.SUCCESS);
     when(resp.getStringPayload()).thenReturn(JSON.serialize(new TransferResult(true, "OK", 100)));
-    when(fabricStub.invokeChaincode(eq("cc"), org.mockito.ArgumentMatchers.<List<byte[]>>any())).thenReturn(resp);
+    when(fabricStub.invokeChaincode(eq("cc"), org.mockito.ArgumentMatchers.<List<byte[]>>any()))
+        .thenReturn(resp);
 
     TransferResult res = ctx.invoke("cc", "fn").returning(TransferResult.class).execute();
     assertThat(res.approved()).isTrue();
@@ -283,17 +292,19 @@ public class PrototypeTests {
     Response resp = mock(Response.class);
     when(resp.getStatus()).thenReturn(Response.Status.INTERNAL_SERVER_ERROR);
     when(resp.getMessage()).thenReturn("chaincode panicked");
-    when(fabricStub.invokeChaincode(eq("testCC"), org.mockito.ArgumentMatchers.<List<byte[]>>any())).thenReturn(resp);
+    when(fabricStub.invokeChaincode(eq("testCC"), org.mockito.ArgumentMatchers.<List<byte[]>>any()))
+        .thenReturn(resp);
 
     assertThatThrownBy(() -> ctx.invoke("testCC", "doWork").returningVoid().execute())
-      .isInstanceOf(CrossChaincodeException.class)
-      .satisfies(e -> {
-        CrossChaincodeException ex = (CrossChaincodeException) e;
-        assertThat(ex.getChaincodeId()).isEqualTo("testCC");
-        assertThat(ex.getFunctionName()).isEqualTo("doWork");
-        assertThat(ex.getStatusCode()).isEqualTo(500);
-        assertThat(ex.getOriginalMessage()).isEqualTo("chaincode panicked");
-      });
+        .isInstanceOf(CrossChaincodeException.class)
+        .satisfies(
+            e -> {
+              CrossChaincodeException ex = (CrossChaincodeException) e;
+              assertThat(ex.getChaincodeId()).isEqualTo("testCC");
+              assertThat(ex.getFunctionName()).isEqualTo("doWork");
+              assertThat(ex.getStatusCode()).isEqualTo(500);
+              assertThat(ex.getOriginalMessage()).isEqualTo("chaincode panicked");
+            });
   }
 
   @Test
@@ -306,7 +317,8 @@ public class PrototypeTests {
 
     Response resp = mock(Response.class);
     when(resp.getStatus()).thenReturn(Response.Status.SUCCESS);
-    when(fabricStub.invokeChaincode(eq("cc"), org.mockito.ArgumentMatchers.<List<byte[]>>any())).thenReturn(resp);
+    when(fabricStub.invokeChaincode(eq("cc"), org.mockito.ArgumentMatchers.<List<byte[]>>any()))
+        .thenReturn(resp);
 
     Void res = ctx.invoke("cc", "fn").returningVoid().execute();
     assertThat(res).isNull();
@@ -321,16 +333,22 @@ public class PrototypeTests {
     when(ctx.getFabricStub()).thenReturn(dummyStub);
     when(ctx.invoke(anyString(), anyString())).thenCallRealMethod();
     assertThatThrownBy(() -> ctx.invoke("cc", "fn").execute())
-      .isInstanceOf(IllegalStateException.class)
-      .hasMessageContaining("returning(Class) or .returningVoid()");
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("returning(Class) or .returningVoid()");
   }
 
   @Test
   public void testCrossChaincode_MixedArgs() {
     HypernateContext ctx = mock(HypernateContext.class);
     when(ctx.invoke(anyString(), anyString())).thenCallRealMethod();
-    assertThatThrownBy(() -> ctx.invoke("cc", "fn").withArgs("x").withRawArgs("y".getBytes()).returningVoid().execute())
-      .isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(
+            () ->
+                ctx.invoke("cc", "fn")
+                    .withArgs("x")
+                    .withRawArgs("y".getBytes())
+                    .returningVoid()
+                    .execute())
+        .isInstanceOf(IllegalStateException.class);
   }
 
   @Test
@@ -343,91 +361,107 @@ public class PrototypeTests {
   @Test
   public void testEndorsementPolicyValidation_Unbalanced1() {
     assertThatThrownBy(() -> EndorsementPolicy.of("OR('Org1MSP.peer'"))
-      .isInstanceOf(InvalidEndorsementPolicyException.class)
-      .hasMessageContaining("Unclosed parenthesis");
+        .isInstanceOf(InvalidEndorsementPolicyException.class)
+        .hasMessageContaining("Unclosed parenthesis");
   }
 
   @Test
   public void testEndorsementPolicyValidation_Unbalanced2() {
     assertThatThrownBy(() -> EndorsementPolicy.of(")OR('Org1MSP.peer')"))
-      .isInstanceOf(InvalidEndorsementPolicyException.class)
-      .hasMessageContaining("Unexpected closing parenthesis");
+        .isInstanceOf(InvalidEndorsementPolicyException.class)
+        .hasMessageContaining("Unexpected closing parenthesis");
   }
 
   @Test
   public void testEndorsementPolicyValidation_UnsupportedFunction() {
     assertThatThrownBy(() -> EndorsementPolicy.of("XOR('Org1MSP.peer')"))
-      .isInstanceOf(InvalidEndorsementPolicyException.class)
-      .hasMessageContaining("Unsupported policy function 'XOR'");
+        .isInstanceOf(InvalidEndorsementPolicyException.class)
+        .hasMessageContaining("Unsupported policy function 'XOR'");
   }
 
   @Test
   public void testEndorsementPolicyValidation_InvalidMSPFormat() {
     assertThatThrownBy(() -> EndorsementPolicy.of("OR('Org1.peer')"))
-      .isInstanceOf(InvalidEndorsementPolicyException.class)
-      .hasMessageContaining("Invalid MSP principal");
+        .isInstanceOf(InvalidEndorsementPolicyException.class)
+        .hasMessageContaining("Invalid MSP principal");
   }
 
   @Test
   public void testEndorsementPolicyValidation_InvalidRole() {
     assertThatThrownBy(() -> EndorsementPolicy.of("OR('Org1MSP.validator')"))
-      .isInstanceOf(InvalidEndorsementPolicyException.class)
-      .hasMessageContaining("Invalid MSP principal");
+        .isInstanceOf(InvalidEndorsementPolicyException.class)
+        .hasMessageContaining("Invalid MSP principal");
   }
 
   @Test
   public void testEndorsementPolicyValidation_Empty() {
     assertThatThrownBy(() -> EndorsementPolicy.of(""))
-      .isInstanceOf(InvalidEndorsementPolicyException.class);
+        .isInstanceOf(InvalidEndorsementPolicyException.class);
   }
 
   @Test
   public void testEndorsementPolicyValidation_OutOfArg() {
     assertThatThrownBy(() -> EndorsementPolicy.of("OutOf(two, 'Org1MSP.peer')"))
-      .isInstanceOf(InvalidEndorsementPolicyException.class)
-      .hasMessageContaining("integer as its first argument");
+        .isInstanceOf(InvalidEndorsementPolicyException.class)
+        .hasMessageContaining("integer as its first argument");
   }
 
   @Test
   public void testEndorsementPolicyBuilder_AND() {
-    EndorsementPolicy built = EndorsementPolicy.builder().and().org("Org1").peer().org("Org2").peer().build();
+    EndorsementPolicy built =
+        EndorsementPolicy.builder().and().org("Org1").peer().org("Org2").peer().build();
     assertThat(built.getExpression()).isEqualTo("AND('Org1MSP.peer', 'Org2MSP.peer')");
   }
 
   @Test
   public void testEndorsementPolicyBuilder_OutOf() {
-    EndorsementPolicy built = EndorsementPolicy.builder().outOf(2).org("Org1").peer().org("Org2").peer().org("Org3").peer().build();
-    assertThat(built.getExpression()).isEqualTo("OutOf(2, 'Org1MSP.peer', 'Org2MSP.peer', 'Org3MSP.peer')");
+    EndorsementPolicy built =
+        EndorsementPolicy.builder()
+            .outOf(2)
+            .org("Org1")
+            .peer()
+            .org("Org2")
+            .peer()
+            .org("Org3")
+            .peer()
+            .build();
+    assertThat(built.getExpression())
+        .isEqualTo("OutOf(2, 'Org1MSP.peer', 'Org2MSP.peer', 'Org3MSP.peer')");
   }
 
   @Test
   public void testEndorsementPolicyBuilder_EqualsDirect() {
     String expr = "OR('Org1MSP.peer', 'Org2MSP.peer')";
     EndorsementPolicy direct = EndorsementPolicy.of(expr);
-    EndorsementPolicy built = EndorsementPolicy.builder().or().org("Org1").peer().org("Org2").peer().build();
+    EndorsementPolicy built =
+        EndorsementPolicy.builder().or().org("Org1").peer().org("Org2").peer().build();
     assertThat(direct.getExpression()).isEqualTo(built.getExpression());
   }
 
   @Test
   public void testEndorsementPolicyBuilder_Empty() {
-    assertThatThrownBy(() -> EndorsementPolicy.builder().build()).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> EndorsementPolicy.builder().build())
+        .isInstanceOf(IllegalStateException.class);
   }
 
   @Test
   public void testEndorsementPolicyBuilder_ExceedsThreshold() {
     assertThatThrownBy(() -> EndorsementPolicy.builder().outOf(3).org("Org1").peer().build())
-      .isInstanceOf(IllegalStateException.class)
-      .hasMessageContaining("exceeds number of principals");
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("exceeds number of principals");
   }
 
   @Test
   public void testRegistryEndorsement_mustCreateSensitive() throws Exception {
     ChaincodeStub fabricStub = mock(ChaincodeStub.class);
-    when(fabricStub.createCompositeKey(anyString(), any(String[].class))).thenReturn(new CompositeKey("mock"));
+    when(fabricStub.createCompositeKey(anyString(), any(String[].class)))
+        .thenReturn(new CompositeKey("mock"));
     when(fabricStub.getState(anyString())).thenReturn(null);
     Registry registry = new Registry(fabricStub);
 
-    SensitiveAsset sensitiveAsset = new SensitiveAsset("id", "red", 1, "owner", 10, 0, AssetStatus.ACTIVE, "A", Collections.emptyList());
+    SensitiveAsset sensitiveAsset =
+        new SensitiveAsset(
+            "id", "red", 1, "owner", 10, 0, AssetStatus.ACTIVE, "A", Collections.emptyList());
     registry.mustCreate(sensitiveAsset);
 
     verify(fabricStub).setStateValidationParameter(anyString(), any(byte[].class));
@@ -436,7 +470,8 @@ public class PrototypeTests {
   @Test
   public void testRegistryEndorsement_mustCreateNormal() throws Exception {
     ChaincodeStub fabricStub = mock(ChaincodeStub.class);
-    when(fabricStub.createCompositeKey(anyString(), any(String[].class))).thenReturn(new CompositeKey("mock"));
+    when(fabricStub.createCompositeKey(anyString(), any(String[].class)))
+        .thenReturn(new CompositeKey("mock"));
     when(fabricStub.getState(anyString())).thenReturn(null);
     Registry registry = new Registry(fabricStub);
 
@@ -449,30 +484,33 @@ public class PrototypeTests {
   @Test
   public void testRegistryEndorsement_setEndorsementPolicyNotFound() {
     ChaincodeStub fabricStub = mock(ChaincodeStub.class);
-    when(fabricStub.createCompositeKey(anyString(), any(String[].class))).thenReturn(new CompositeKey("mock"));
+    when(fabricStub.createCompositeKey(anyString(), any(String[].class)))
+        .thenReturn(new CompositeKey("mock"));
     when(fabricStub.getState(anyString())).thenReturn(new byte[0]);
     Registry registry = new Registry(fabricStub);
-    
+
     Asset asset = new Asset("id", "red", 1, "owner", 10);
     EndorsementPolicy pol = EndorsementPolicy.of("OR('Org1MSP.peer')");
-    
+
     assertThatThrownBy(() -> registry.setEndorsementPolicy(asset, pol))
-      .isInstanceOf(EntityNotFoundException.class)
-      .hasMessageContaining("Cannot set endorsement policy: entity does not exist");
+        .isInstanceOf(EntityNotFoundException.class)
+        .hasMessageContaining("Cannot set endorsement policy: entity does not exist");
   }
 
   @Test
   public void testSampleChaincode_createAssetBlankId() {
     SampleChaincode sc = new SampleChaincode();
     ChaincodeStub fabricStub = mock(ChaincodeStub.class);
-    org.hyperledger.fabric.shim.ext.sbe.StateBasedEndorsement sbe = mock(org.hyperledger.fabric.shim.ext.sbe.StateBasedEndorsement.class);
+    org.hyperledger.fabric.shim.ext.sbe.StateBasedEndorsement sbe =
+        mock(org.hyperledger.fabric.shim.ext.sbe.StateBasedEndorsement.class);
     when(fabricStub.getTxTimestamp()).thenReturn(java.time.Instant.now());
     HypernateContext ctx = mock(HypernateContext.class);
     when(ctx.getStub()).thenReturn(fabricStub);
     when(ctx.getFabricStub()).thenReturn(fabricStub);
     when(ctx.getRegistry()).thenReturn(new Registry(fabricStub));
     assertThatThrownBy(() -> sc.createAsset(ctx, "", "red", 10, "Alice", 100))
-      .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("id");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("id");
   }
 
   @Test
@@ -485,16 +523,18 @@ public class PrototypeTests {
     when(ctx.getFabricStub()).thenReturn(fabricStub);
     when(ctx.getRegistry()).thenReturn(new Registry(fabricStub));
     assertThatThrownBy(() -> sc.createAsset(ctx, "a1", "red", -1, "Alice", 100))
-      .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("size");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("size");
   }
 
   @Test
   public void testSampleChaincode_initiateTransferArchived() throws Exception {
     ChaincodeStub fabricStub = mock(ChaincodeStub.class);
-    when(fabricStub.createCompositeKey(anyString(), any(String[].class))).thenReturn(new CompositeKey("mock"));
+    when(fabricStub.createCompositeKey(anyString(), any(String[].class)))
+        .thenReturn(new CompositeKey("mock"));
     Asset archived = new Asset("id", "red", 1, "owner", 10, 0, AssetStatus.ARCHIVED);
     when(fabricStub.getState(anyString())).thenReturn(JSON.serialize(archived).getBytes());
-    
+
     SampleChaincode sc = new SampleChaincode();
     HypernateContext ctx = mock(HypernateContext.class);
     when(ctx.getRegistry()).thenReturn(new Registry(fabricStub));
@@ -503,20 +543,25 @@ public class PrototypeTests {
     when(ctx.invoke(anyString(), anyString())).thenCallRealMethod();
 
     assertThatThrownBy(() -> sc.initiateTransfer(ctx, "id", "owner", "new", 10))
-      .isInstanceOf(RuntimeException.class).hasMessageContaining("not in ACTIVE status");
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("not in ACTIVE status");
   }
 
   @Test
   public void testSampleChaincode_initiateTransferRejected() throws Exception {
     ChaincodeStub fabricStub = mock(ChaincodeStub.class);
-    when(fabricStub.createCompositeKey(anyString(), any(String[].class))).thenReturn(new CompositeKey("mock"));
+    when(fabricStub.createCompositeKey(anyString(), any(String[].class)))
+        .thenReturn(new CompositeKey("mock"));
     Asset active = new Asset("id", "red", 1, "owner", 10, 0, AssetStatus.ACTIVE);
     when(fabricStub.getState(anyString())).thenReturn(JSON.serialize(active).getBytes());
-    
+
     Response resp = mock(Response.class);
     when(resp.getStatus()).thenReturn(Response.Status.SUCCESS);
-    when(resp.getStringPayload()).thenReturn(JSON.serialize(new PricingResponse(false, 0, "Too low")));
-    when(fabricStub.invokeChaincode(eq("PricingChaincode"), org.mockito.ArgumentMatchers.<List<byte[]>>any())).thenReturn(resp);
+    when(resp.getStringPayload())
+        .thenReturn(JSON.serialize(new PricingResponse(false, 0, "Too low")));
+    when(fabricStub.invokeChaincode(
+            eq("PricingChaincode"), org.mockito.ArgumentMatchers.<List<byte[]>>any()))
+        .thenReturn(resp);
 
     SampleChaincode sc = new SampleChaincode();
     HypernateContext ctx = mock(HypernateContext.class);
@@ -526,20 +571,24 @@ public class PrototypeTests {
     when(ctx.invoke(anyString(), anyString())).thenCallRealMethod();
 
     assertThatThrownBy(() -> sc.initiateTransfer(ctx, "id", "owner", "new", 10))
-      .isInstanceOf(RuntimeException.class).hasMessageContaining("Transfer rejected");
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Transfer rejected");
   }
 
   @Test
   public void testSampleChaincode_initiateTransferSuccess() throws Exception {
     ChaincodeStub fabricStub = mock(ChaincodeStub.class);
-    when(fabricStub.createCompositeKey(anyString(), any(String[].class))).thenReturn(new CompositeKey("mock"));
+    when(fabricStub.createCompositeKey(anyString(), any(String[].class)))
+        .thenReturn(new CompositeKey("mock"));
     Asset active = new Asset("id", "red", 1, "owner", 10, 0, AssetStatus.ACTIVE);
     when(fabricStub.getState(anyString())).thenReturn(JSON.serialize(active).getBytes());
-    
+
     Response resp = mock(Response.class);
     when(resp.getStatus()).thenReturn(Response.Status.SUCCESS);
     when(resp.getStringPayload()).thenReturn(JSON.serialize(new PricingResponse(true, 50, "OK")));
-    when(fabricStub.invokeChaincode(eq("PricingChaincode"), org.mockito.ArgumentMatchers.<List<byte[]>>any())).thenReturn(resp);
+    when(fabricStub.invokeChaincode(
+            eq("PricingChaincode"), org.mockito.ArgumentMatchers.<List<byte[]>>any()))
+        .thenReturn(resp);
 
     SampleChaincode sc = new SampleChaincode();
     HypernateContext ctx = mock(HypernateContext.class);

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,5 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
 rootProject.name = "hypernate"
 include("lib")


### PR DESCRIPTION

This PR adds the first working prototype for some of the bigger Hypernate abstractions discussed in the LFX project proposal.

Currently includes:
- fluent CouchDB query builder
- composite key range query support
- registry CRUD improvements
- state-based endorsement policy DSL
- cross-chaincode invocation helpers
- middleware transaction safety checks

Most of the focus here was around making the APIs feel natural to use while still keeping Fabric-specific edge cases guarded properly.

Also added validation for invalid query/range states, endorsement expressions, and unsafe reads during uncommitted middleware writes.

Everything is covered with tests right now (`70/70` passing on JDK 17).

Mainly opening this as an early WIP/draft PR for architectural and API feedback before expanding the implementation further.

Refs LF-Decentralized-Trust-Mentorships/mentorship-program#86