### PR TITLE
Add CI automations to check and enforce contribution guidelines

### DIFF
--- a/.github/scripts/check_design_approval.js
+++ b/.github/scripts/check_design_approval.js
@@ -1,0 +1,177 @@
+/*
+ * Checks that a PR has at least one linked issue carrying the `design/approved` label.
+ * If not, it applies a `needs-approved-issue` label and posts an explanatory comment.
+ *
+ * Usage (called by the workflow via actions/github-script):
+ *   const script = require('./.github/scripts/check_design_approval.js')
+ *   await script({ github, context, core })
+ */
+
+const REQUIRED_LABEL = 'design/approved'
+const FLAG_LABEL = 'needs-approved-issue'
+
+// Fetch everything we need in a single GraphQL query:
+// - Linked issues + their labels
+// - Current labels on the PR
+// - Existing bot comments on the PR (to avoid duplicate comments)
+const QUERY = `
+  query CheckDesignApproval($owner: String!, $repo: String!, $prNumber: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $prNumber) {
+        author { login }
+        labels(first: 10) {
+          nodes { name }
+        }
+        comments(last: 50) {
+          nodes {
+            body
+            author {
+              login
+              __typename
+            }
+          }
+        }
+        closingIssuesReferences(first: 10) {
+          nodes {
+            number
+            labels(first: 10) {
+              nodes { name }
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
+/**
+ * Ensure a label exists in the repo, creating it if necessary.
+ * @param {object} github  - Octokit instance from github-script
+ * @param {object} repo    - { owner, repo }
+ * @param {string} label
+ */
+async function ensureLabelExists (github, repo, label) {
+  try {
+    await github.rest.issues.getLabel({ ...repo, name: label })
+  } catch (err) {
+    if (err.status === 404) {
+      await github.rest.issues.createLabel({
+        ...repo,
+        name: label,
+        color: 'fbca04',
+        description: 'PR is not linked to a design/approved issue'
+      })
+    } else {
+      throw err
+    }
+  }
+}
+
+/**
+ * Entry point called by the actions/github-script workflow step.
+ */
+module.exports = async ({ github, context, core }) => {
+  const { owner, repo } = context.repo
+  const prNumber = context.payload.pull_request.number
+
+  core.info(`Checking PR #${prNumber}`)
+
+  // ── 1. Single GraphQL query that reads all data ─────────────────────
+  const { repository } = await github.graphql(QUERY, {
+    owner,
+    repo,
+    prNumber
+  })
+
+  const pr = repository.pullRequest
+  const prAuthor = pr.author.login
+  const currentLabelNames = pr.labels.nodes.map((l) => l.name)
+  const linkedIssues = pr.closingIssuesReferences.nodes
+
+  core.info(
+    linkedIssues.length
+      ? `Found ${linkedIssues.length} linked issue(s): ${linkedIssues.map((i) => `#${i.number}`).join(', ')}`
+      : 'No linked issues found.'
+  )
+
+  // ── 2. Check linked issues for the required label ───────────────────
+  let approvedIssue = null
+  for (const issue of linkedIssues) {
+    const issueLabels = issue.labels.nodes.map((l) => l.name)
+    core.info(`Issue #${issue.number} labels: [${issueLabels.join(', ')}]`)
+    if (issueLabels.includes(REQUIRED_LABEL)) {
+      core.info(`✅ Issue #${issue.number} has '${REQUIRED_LABEL}' – PR passes.`)
+      approvedIssue = issue
+      break
+    }
+  }
+
+  const alreadyFlagged = currentLabelNames.includes(FLAG_LABEL)
+
+  // ── 3a. PR passes; clean up flag label if previously applied ────────
+  if (approvedIssue) {
+    if (alreadyFlagged) {
+      core.info(`Removing '${FLAG_LABEL}' label as the PR now passes.`)
+      await github.rest.issues.removeLabel({
+        owner,
+        repo,
+        issue_number: prNumber,
+        name: FLAG_LABEL
+      })
+    }
+    return
+  }
+
+  // ── 3b. PR fails; apply label + comment ─────────────────────────────
+  core.info(`PR #${prNumber} does not meet requirements.`)
+
+  await ensureLabelExists(github, { owner, repo }, FLAG_LABEL)
+
+  if (!alreadyFlagged) {
+    await github.rest.issues.addLabels({
+      owner,
+      repo,
+      issue_number: prNumber,
+      labels: [FLAG_LABEL]
+    })
+    core.info(`Applied '${FLAG_LABEL}' label.`)
+  }
+
+  // Bot comments have __typename "Bot" on the author node in GraphQL.
+  const alreadyCommented = pr.comments.nodes.some(
+    (c) => c.author.__typename === 'Bot' && c.body.includes(REQUIRED_LABEL)
+  )
+  if (!alreadyCommented) {
+    const message =
+      linkedIssues.length === 0
+        ? `Hey @${prAuthor}, thanks for the contribution! 👋
+ 
+This PR was flagged because it has no linked issues.  Please link one using a closing keyword in the PR description; for example:
+ 
+\`\`\`
+Closes #<issue-number>
+\`\`\`
+ 
+The linked issue must also carry the \`${REQUIRED_LABEL}\` label.  If no issue exists yet, please open one and get design approval from the maintainers first.`
+        : `Hey @${prAuthor}, thanks for the contribution! 👋
+ 
+This PR was flagged because the linked issue(s) (${linkedIssues.map((i) => `#${i.number}`).join(', ')}) do not have the \`${REQUIRED_LABEL}\` label.
+ 
+Please ensure the linked issue has been through the design approval process and carries the \`${REQUIRED_LABEL}\` label before this PR can be merged.`
+
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: prNumber,
+      body: message
+    })
+    core.info('Posted explanatory comment.')
+  } else {
+    core.info('Comment already exists; skipping to avoid spam.')
+  }
+
+  // Signal failure so the check shows as ❌ in the PR's status checks.
+  core.setFailed(
+    `PR #${prNumber} is not linked to an issue with the '${REQUIRED_LABEL}' label.`
+  )
+}

--- a/.github/workflows/check_design_approval.yml
+++ b/.github/workflows/check_design_approval.yml
@@ -1,0 +1,27 @@
+---
+name: Flag PRs that do not have associated design/approved issues
+
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+
+jobs:
+  check:
+    name: Linked issue has design/approved
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run design-approval check
+        uses: actions/github-script@v9
+        with:
+          script: |-
+            const script = require('./.github/scripts/check_design_approval.js')
+            await script({ github, context, core })

--- a/.github/workflows/stale_not_approved.yml
+++ b/.github/workflows/stale_not_approved.yml
@@ -1,0 +1,31 @@
+---
+name: >-
+  Mark PRs without design/approved linked issues as stale
+  and eventually close them
+
+
+on:
+  schedule:
+    - cron: 30 1 * * *
+
+
+permissions:
+  pull-requests: write
+
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          stale-pr-message: |-
+            This PR has been automatically marked as stale due to inactivity.
+            It will be closed in 60 days if no further activity occurs.
+          days-before-stale: 14
+          days-before-close: 60
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          stale-pr-label: stale
+          exempt-pr-labels: pinned,security
+          any-of-labels: needs-approved-issue

--- a/.github/workflows/triage_label.yml
+++ b/.github/workflows/triage_label.yml
@@ -1,0 +1,24 @@
+---
+name: Auto-add needs-triage labels to new issues
+
+
+on:
+  issues:
+    types: [opened]
+
+
+permissions:
+  issues: write
+
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - run: >-
+          gh issue
+          edit ${{ github.event.issue.number }}
+          --add-label needs-triage
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}

--- a/docs/guides/cicd.md
+++ b/docs/guides/cicd.md
@@ -4,9 +4,12 @@ This project uses GitHub Actions for continuous integration and delivery.
 
 ## Workflows
 
-| Workflow     | File                          | Purpose                                   |
-| ------------ | ----------------------------- | ----------------------------------------- |
-| Build & Test | `.github/workflows/build.yml` | Formatting checks, compilation, and tests |
+| Workflow         | File                                         | Purpose                                                   |
+| ---------------- | -------------------------------------------- | --------------------------------------------------------- |
+| Build & Test     | `.github/workflows/build.yml`                | Formatting checks, compilation, and tests                 |
+| Triage Label     | `.github/workflows/triage_label.yml`         | Labels newly opened issues with `needs-triage`            |
+| Design Approval  | `.github/workflows/check_design_approval.yml`| Flags PRs without a linked design/approved issue          |
+| Stale PRs        | `.github/workflows/stale_not_approved.yml`   | Marks and eventually closes stale, non-approved PRs       |
 
 ## Build & Test
 
@@ -17,6 +20,25 @@ Documentation-only changes are skipped via path filters.
 
 If a new commit is pushed while a run is already in progress for the same branch, the older run is
 automatically canceled.
+
+## Triage Label
+
+When an issue is opened, the Triage Label workflow automatically adds the `needs-triage` label so
+new issues are easy to find and route.
+
+## Design Approval
+
+On every pull request (opened, edited, synchronized, or reopened), the Design Approval workflow checks that the PR links to an issue carrying the `design/approved` label.
+PRs that lack such a linked issue are flagged via the `needs-approved-issue` label.
+
+Because the workflow is triggered by changes to the PR, it will not rerun if a non-`design/approved` issue gets the `design/approved` label.
+In these cases, either a maintainer can force rerun the check or you can make a dummy change to the PR body (like adding a newline) and it will trigger the workflow.
+
+## Stale PRs
+
+A scheduled daily job marks pull requests carrying the `needs-approved-issue` label as `stale`
+after 14 days of inactivity and closes them after 60 days. PRs labeled `pinned` or `security` are
+exempt. Issues are never affected.
 
 ## Reading CI Results
 


### PR DESCRIPTION
Closes #120

The logic of the PR check is available in a separate `js` script under `.github/scripts/` to make it hopefully more maintainable than as a YAML string.