### PR TITLE
feat(identity): typed accessor for Fabric ClientIdentity

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/docs/concepts/identity.md
+++ b/docs/concepts/identity.md
@@ -1,0 +1,62 @@
+# Identity Wrapper
+
+The `Identity` class provides a thin, typed wrapper around Hyperledger Fabric's raw `ClientIdentity`. It simplifies access control checks by offering consistent API semantics, automatic exception wrapping, and direct integration with the transaction context.
+
+## Motivation
+
+In standard Hyperledger Fabric chaincodes, checking client attributes and MSP IDs typically involves writing repetitive boilerplate:
+* Instantiating `ClientIdentity` (which throws several checked exceptions: `CertificateException`, `IOException`, `JSONException`).
+* Manually checking for `null` when retrieving attribute values.
+* Explicitly throwing exceptions on access control failures.
+
+Hypernate's `Identity` class eliminates this by wrappingchecked exceptions into runtime exceptions at construction time and providing `must*`, `try*`, and `require*` semantics.
+
+---
+
+## API & Semantics
+
+The `Identity` wrapper offers the following operations:
+
+### Identity Details
+* `getId()`: Returns the unique identifier of the submitting client identity.
+* `getMspId()`: Returns the Membership Service Provider (MSP) ID of the client's organization.
+
+### Attribute Verification
+* `mustGetAttribute(name)`: Retrieves the attribute value, throwing an `AttributeNotFoundException` if it is not present.
+* `tryGetAttribute(name)`: Safely retrieves the attribute value, returning `null` if the attribute does not exist.
+* `hasAttribute(name, value)`: Returns a boolean indicating whether the client possesses the specified attribute and if its value matches.
+* `requireAttribute(name, value)`: Asserts that the client has the specified attribute and value, throwing an `AccessDeniedException` if they do not.
+
+### MSP (Organization) Verification
+* `isFromMsp(mspId)`: Returns a boolean indicating whether the client belongs to the specified MSP ID.
+* `requireMsp(mspId)`: Asserts that the client belongs to the specified MSP ID, throwing an `AccessDeniedException` if they do not.
+
+---
+
+## Usage Example
+
+The identity wrapper is lazily initialized and accessible directly via `HypernateContext`:
+
+```java
+public void transferAsset(final HypernateContext ctx, final String assetID, final String newOwner) {
+    // 1. Enforce that only users from Org1MSP can execute this transaction
+    ctx.getIdentity().requireMsp("Org1MSP");
+
+    // 2. Enforce that the user possesses the "admin" role
+    ctx.getIdentity().requireAttribute("role", "admin");
+
+    // 3. Proceed with transaction logic
+    Asset asset = ctx.getRegistry().mustRead(Asset.class, assetID);
+    asset.setOwner(newOwner);
+    ctx.getRegistry().mustUpdate(asset);
+}
+```
+
+---
+
+## Exception Hierarchy
+
+All custom identity exceptions extend `HypernateException`:
+* **`IdentityException`**: Thrown for general identity setup and initialization errors.
+* **`AttributeNotFoundException`**: Thrown when a mandatory attribute is missing during `mustGetAttribute()`.
+* **`AccessDeniedException`**: Thrown when security constraints are violated during `requireAttribute()` or `requireMsp()`.

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
   implementation("com.jcabi:jcabi-aspects:0.26.0")
   implementation("org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.0")
   implementation("org.hyperledger.fabric:fabric-protos:0.3.0")
+  implementation("org.json:json:20231013")
 
   aspect("com.jcabi:jcabi-aspects:0.26.0")
 

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/context/HypernateContext.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/context/HypernateContext.java
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 package hu.bme.mit.ftsrg.hypernate.context;
 
+import hu.bme.mit.ftsrg.hypernate.identity.Identity;
 import hu.bme.mit.ftsrg.hypernate.middleware.StubMiddleware;
 import hu.bme.mit.ftsrg.hypernate.middleware.StubMiddlewareChain;
 import hu.bme.mit.ftsrg.hypernate.middleware.notification.HypernateNotification;
@@ -30,11 +31,25 @@ public class HypernateContext extends Context {
 
   @Getter private final Registry registry;
 
+  private Identity identity;
+
   public HypernateContext(final StubMiddlewareChain middlewareChain) {
     super(middlewareChain.getFirst());
     this.middlewareChain = middlewareChain;
     this.fabricStub = middlewareChain.fabricStub();
     this.registry = new Registry(middlewareChain.getFirst());
+  }
+
+  /**
+   * Gets the Identity wrapper, lazily instantiating it on the first call.
+   *
+   * @return the Identity wrapper singleton associated with this context
+   */
+  public Identity getIdentity() {
+    if (this.identity == null) {
+      this.identity = new Identity(this.middlewareChain.getFirst());
+    }
+    return this.identity;
   }
 
   /**

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/identity/AccessDeniedException.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/identity/AccessDeniedException.java
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.identity;
+
+import hu.bme.mit.ftsrg.hypernate.HypernateException;
+import lombok.experimental.StandardException;
+
+/** Exception thrown when an identity check (MSP or attribute) fails. */
+@StandardException
+public class AccessDeniedException extends HypernateException {}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/identity/AttributeNotFoundException.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/identity/AttributeNotFoundException.java
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.identity;
+
+import hu.bme.mit.ftsrg.hypernate.HypernateException;
+import lombok.experimental.StandardException;
+
+/** Exception thrown when a required identity attribute is not found. */
+@StandardException
+public class AttributeNotFoundException extends HypernateException {}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/identity/Identity.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/identity/Identity.java
@@ -1,0 +1,135 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.identity;
+
+import hu.bme.mit.ftsrg.hypernate.HypernateException;
+import org.hyperledger.fabric.contract.ClientIdentity;
+import org.hyperledger.fabric.shim.ChaincodeStub;
+
+/**
+ * A thin, typed wrapper around Fabric's {@link ClientIdentity} providing clean and consistent
+ * identity, MSP, and attribute checking semantics.
+ */
+public final class Identity {
+
+  private final ClientIdentity clientIdentity;
+
+  /**
+   * Constructs a new Identity wrapper around Fabric's ClientIdentity.
+   *
+   * @param stub the chaincode stub used to retrieve the client identity
+   * @throws HypernateException if the client identity cannot be initialized
+   */
+  public Identity(final ChaincodeStub stub) {
+    try {
+      this.clientIdentity = new ClientIdentity(stub);
+    } catch (Exception e) {
+      throw new IdentityException("Failed to initialize ClientIdentity from stub", e);
+    }
+  }
+
+  /**
+   * Package-private constructor for testing purposes, allowing a mocked ClientIdentity to be
+   * injected.
+   *
+   * @param clientIdentity the mocked/stubbed ClientIdentity
+   */
+  Identity(final ClientIdentity clientIdentity) {
+    this.clientIdentity = clientIdentity;
+  }
+
+  /**
+   * Gets the unique ID of the submitting identity.
+   *
+   * @return the unique ID string
+   */
+  public String getId() {
+    return this.clientIdentity.getId();
+  }
+
+  /**
+   * Gets the MSP ID of the submitting identity's organization.
+   *
+   * @return the MSP ID string
+   */
+  public String getMspId() {
+    return this.clientIdentity.getMSPID();
+  }
+
+  /**
+   * Gets the value of the specified attribute. Throws an exception if the attribute is not found.
+   *
+   * @param name the name of the attribute
+   * @return the attribute value
+   * @throws AttributeNotFoundException if the attribute does not exist
+   */
+  public String mustGetAttribute(final String name) throws AttributeNotFoundException {
+    final String value = tryGetAttribute(name);
+    if (value == null) {
+      throw new AttributeNotFoundException("Attribute not found: " + name);
+    }
+    return value;
+  }
+
+  /**
+   * Gets the value of the specified attribute, returning null if it does not exist.
+   *
+   * @param name the name of the attribute
+   * @return the attribute value, or null if absent
+   */
+  public String tryGetAttribute(final String name) {
+    return this.clientIdentity.getAttributeValue(name);
+  }
+
+  /**
+   * Checks if the identity has the specified attribute with the expected value.
+   *
+   * @param name the name of the attribute
+   * @param value the expected value of the attribute
+   * @return true if the attribute exists and matches the expected value, false otherwise
+   */
+  public boolean hasAttribute(final String name, final String value) {
+    final String actualValue = tryGetAttribute(name);
+    return actualValue != null && actualValue.equals(value);
+  }
+
+  /**
+   * Requires that the identity has the specified attribute with the expected value. Throws an
+   * exception if the check fails.
+   *
+   * @param name the name of the attribute
+   * @param value the expected value of the attribute
+   * @throws AccessDeniedException if the attribute check fails
+   */
+  public void requireAttribute(final String name, final String value) throws AccessDeniedException {
+    if (!hasAttribute(name, value)) {
+      throw new AccessDeniedException(
+          String.format(
+              "Access denied: missing or invalid attribute '%s' (expected '%s')", name, value));
+    }
+  }
+
+  /**
+   * Checks if the submitting identity is from the specified MSP.
+   *
+   * @param mspId the expected MSP ID
+   * @return true if the user belongs to the specified MSP, false otherwise
+   */
+  public boolean isFromMsp(final String mspId) {
+    return getMspId().equals(mspId);
+  }
+
+  /**
+   * Requires that the submitting identity is from the specified MSP. Throws an exception if the
+   * check fails.
+   *
+   * @param mspId the expected MSP ID
+   * @throws AccessDeniedException if the user belongs to a different MSP
+   */
+  public void requireMsp(final String mspId) throws AccessDeniedException {
+    if (!isFromMsp(mspId)) {
+      throw new AccessDeniedException(
+          String.format(
+              "Access denied: required MSP '%s', but user belongs to MSP '%s'", mspId, getMspId()));
+    }
+  }
+}

--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/identity/IdentityException.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/identity/IdentityException.java
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.identity;
+
+import hu.bme.mit.ftsrg.hypernate.HypernateException;
+import lombok.experimental.StandardException;
+
+/** Exception thrown for general identity-related errors, including initialization failures. */
+@StandardException
+public class IdentityException extends HypernateException {}

--- a/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/identity/IdentityTest.java
+++ b/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/identity/IdentityTest.java
@@ -1,0 +1,160 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.identity;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+import org.hyperledger.fabric.contract.ClientIdentity;
+import org.hyperledger.fabric.shim.ChaincodeStub;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class IdentityTest {
+
+  @Mock private ClientIdentity mockClientIdentity;
+  @Mock private ChaincodeStub mockStub;
+
+  private Identity identity;
+
+  @BeforeEach
+  void setUp() {
+    identity = new Identity(mockClientIdentity);
+  }
+
+  @Test
+  void constructor_throws_IdentityException_on_ClientIdentity_failure() {
+    // If the stub returns null creator, the ClientIdentity constructor will throw an exception
+    given(mockStub.getCreator()).willReturn(null);
+
+    assertThrows(IdentityException.class, () -> new Identity(mockStub));
+  }
+
+  @Test
+  void getId_returns_id_from_client_identity() {
+    given(mockClientIdentity.getId()).willReturn("user-123");
+
+    assertEquals("user-123", identity.getId());
+  }
+
+  @Test
+  void getMspId_returns_msp_id_from_client_identity() {
+    given(mockClientIdentity.getMSPID()).willReturn("Org1MSP");
+
+    assertEquals("Org1MSP", identity.getMspId());
+  }
+
+  @Nested
+  class attribute_checks {
+
+    @Test
+    void mustGetAttribute_returns_value_when_present() {
+      given(mockClientIdentity.getAttributeValue("role")).willReturn("admin");
+
+      assertEquals("admin", identity.mustGetAttribute("role"));
+    }
+
+    @Test
+    void mustGetAttribute_throws_AttributeNotFoundException_when_absent() {
+      given(mockClientIdentity.getAttributeValue("role")).willReturn(null);
+
+      assertThrows(AttributeNotFoundException.class, () -> identity.mustGetAttribute("role"));
+    }
+
+    @Test
+    void tryGetAttribute_returns_value_when_present() {
+      given(mockClientIdentity.getAttributeValue("department")).willReturn("engineering");
+
+      assertEquals("engineering", identity.tryGetAttribute("department"));
+    }
+
+    @Test
+    void tryGetAttribute_returns_null_when_absent() {
+      given(mockClientIdentity.getAttributeValue("department")).willReturn(null);
+
+      assertNull(identity.tryGetAttribute("department"));
+    }
+
+    @Test
+    void hasAttribute_returns_true_when_matches() {
+      given(mockClientIdentity.getAttributeValue("role")).willReturn("editor");
+
+      assertTrue(identity.hasAttribute("role", "editor"));
+    }
+
+    @Test
+    void hasAttribute_returns_false_when_mismatches() {
+      given(mockClientIdentity.getAttributeValue("role")).willReturn("viewer");
+
+      assertFalse(identity.hasAttribute("role", "editor"));
+    }
+
+    @Test
+    void hasAttribute_returns_false_when_absent() {
+      given(mockClientIdentity.getAttributeValue("role")).willReturn(null);
+
+      assertFalse(identity.hasAttribute("role", "editor"));
+    }
+
+    @Test
+    void requireAttribute_passes_when_matches() {
+      given(mockClientIdentity.getAttributeValue("role")).willReturn("admin");
+
+      assertDoesNotThrow(() -> identity.requireAttribute("role", "admin"));
+    }
+
+    @Test
+    void requireAttribute_throws_AccessDeniedException_when_mismatches() {
+      given(mockClientIdentity.getAttributeValue("role")).willReturn("user");
+
+      assertThrows(AccessDeniedException.class, () -> identity.requireAttribute("role", "admin"));
+    }
+
+    @Test
+    void requireAttribute_throws_AccessDeniedException_when_absent() {
+      given(mockClientIdentity.getAttributeValue("role")).willReturn(null);
+
+      assertThrows(AccessDeniedException.class, () -> identity.requireAttribute("role", "admin"));
+    }
+  }
+
+  @Nested
+  class msp_checks {
+
+    @Test
+    void isFromMsp_returns_true_when_matches() {
+      given(mockClientIdentity.getMSPID()).willReturn("Org1MSP");
+
+      assertTrue(identity.isFromMsp("Org1MSP"));
+    }
+
+    @Test
+    void isFromMsp_returns_false_when_mismatches() {
+      given(mockClientIdentity.getMSPID()).willReturn("Org1MSP");
+
+      assertFalse(identity.isFromMsp("Org2MSP"));
+    }
+
+    @Test
+    void requireMsp_passes_when_matches() {
+      given(mockClientIdentity.getMSPID()).willReturn("Org1MSP");
+
+      assertDoesNotThrow(() -> identity.requireMsp("Org1MSP"));
+    }
+
+    @Test
+    void requireMsp_throws_AccessDeniedException_when_mismatches() {
+      given(mockClientIdentity.getMSPID()).willReturn("Org1MSP");
+
+      assertThrows(AccessDeniedException.class, () -> identity.requireMsp("Org2MSP"));
+    }
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
   - Concepts:
       - Overview: concepts/index.md
       - Registry: concepts/registry.md
+      - Identity: concepts/identity.md
       - Middleware: concepts/middleware.md
       - Annotations: concepts/annotations.md
   - Guides:


### PR DESCRIPTION
### Summary
This PR implements a thin, typed `Identity` wrapper around Hyperledger Fabric's `ClientIdentity` class, exposing it via `HypernateContext`. It provides consistent access and check semantics (`must*`, `try*`, and `require*`) for verifying client identity, MSP, and certificate attributes, matching the ergonomics of `Registry`.

### Key Changes
1. **`Identity` Wrapper Class**:
   - Implemented under `hu.bme.mit.ftsrg.hypernate.identity`.
   - Delegates to `ClientIdentity` with clean methods: `getId()`, `getMspId()`, `tryGetAttribute()`, `mustGetAttribute()`, `hasAttribute()`, `requireAttribute()`, `isFromMsp()`, and `requireMsp()`.
2. **Context Integration**:
   - Added lazy initialization to `HypernateContext#getIdentity()` returning a cached singleton instance per transaction context.
3. **Unchecked Exception Hierarchy**:
   - Created `AttributeNotFoundException` and `AccessDeniedException` extending `HypernateException` with `@StandardException` Lombok support.
   - **Added `IdentityException` (Not in original issue)**:This serves as the specific, typed runtime exception representing any failure when constructing or setting up the identity wrapper
4. **Dependencies**:
   - **Updated `lib/build.gradle.kts` (Not in original issue)**: Added the `org.json:json` dependency to resolve classpath lookup issues of the internal `JSONException` class thrown by Fabric's `ClientIdentity` constructor during testing and runtime.
5. **Testing & Documentation**:
   - Added comprehensive unit tests in `IdentityTest.java` covering all success/failure assertion combinations.
   - Added concepts documentation page `docs/concepts/identity.md` and registered it in `mkdocs.yml`.

### Resolves
Closes #112
