### PR TITLE
feat(registry): implement deletion by key parts

### DIFF
--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/registry/Registry.java
@@ -130,6 +130,44 @@ public class Registry {
   }
 
   /**
+   * Delete an existing entity by its class and primary keys.
+   *
+   * @param clazz the class of the entity
+   * @param keyParts the list of primary keys identifying the entity
+   * @param <T> the entity type
+   * @throws EntityNotFoundException if the entity was not found in the ledger
+   */
+  public <T> void mustDelete(Class<T> clazz, Object... keyParts) throws EntityNotFoundException {
+    final String key = resolveCompositeKey(clazz, keyParts);
+    if (!keyExists(key)) {
+      throw new EntityNotFoundException(key);
+    }
+    stub.delState(key);
+  }
+
+  /**
+   * Delete an entity by its class and primary keys if it exists.
+   *
+   * @param clazz the class of the entity
+   * @param keyParts the list of primary keys identifying the entity
+   * @return {@code true} if the entity was deleted, {@code false} otherwise
+   * @param <T> the entity type
+   */
+  public <T> boolean tryDelete(Class<T> clazz, Object... keyParts) {
+    try {
+      mustDelete(clazz, keyParts);
+    } catch (EntityNotFoundException e) {
+      logger.info(
+          "Entity of type {} with keys {} does not exist -- ignoring delete",
+          clazz.getName(),
+          keyParts);
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
    * Read an existing entity.
    *
    * @param clazz the class of the entity
@@ -139,22 +177,7 @@ public class Registry {
    * @throws EntityNotFoundException if an entity with the given primary keys was not found
    */
   public <T> T mustRead(Class<T> clazz, Object... keyParts) throws EntityNotFoundException {
-    int primaryKeyCount = EntityUtil.getPrimaryKeyCount(clazz);
-    if (primaryKeyCount == 0) {
-      throw new MissingPrimaryKeysException(
-          String.format("%s does not have a primary key annotation", clazz));
-    }
-
-    if (keyParts.length != primaryKeyCount) {
-      throw new IllegalArgumentException(
-          "The number of key parts provided does not match number of primary keys for "
-              + clazz.getName());
-    }
-
-    final String key =
-        stub.createCompositeKey(
-                EntityUtil.getType(clazz), EntityUtil.mapKeyPartsToString(clazz, keyParts))
-            .toString();
+    final String key = resolveCompositeKey(clazz, keyParts);
     final byte[] data = stub.getState(key);
 
     if (data == null || data.length == 0) {
@@ -233,6 +256,24 @@ public class Registry {
 
   private <T> String getCompositeKey(final T ent) {
     return stub.createCompositeKey(EntityUtil.getType(ent), EntityUtil.getPrimaryKeys(ent))
+        .toString();
+  }
+
+  private String resolveCompositeKey(Class<?> clazz, Object[] keyParts) {
+    int primaryKeyCount = EntityUtil.getPrimaryKeyCount(clazz);
+    if (primaryKeyCount == 0) {
+      throw new MissingPrimaryKeysException(
+          String.format("%s does not have a primary key annotation", clazz));
+    }
+
+    if (keyParts.length != primaryKeyCount) {
+      throw new IllegalArgumentException(
+          "The number of key parts provided does not match number of primary keys for "
+              + clazz.getName());
+    }
+
+    return stub.createCompositeKey(
+            EntityUtil.getType(clazz), EntityUtil.mapKeyPartsToString(clazz, keyParts))
         .toString();
   }
 

--- a/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/RegistryTest.java
+++ b/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/RegistryTest.java
@@ -257,6 +257,95 @@ class RegistryTest {
   }
 
   @Nested
+  class when_must_delete_with_key_parts {
+
+    @Test
+    void given_empty_ledger_with_insufficient_key_parts_then_throw_illegal_argument() {
+      assertThrows(
+          IllegalArgumentException.class, () -> registry.mustDelete(TestEntity.class, entity.foo));
+      verifyNoMoreInteractions(stub);
+    }
+
+    @Test
+    void given_empty_ledger_with_complete_key_then_throw_not_found() {
+      given(stub.createCompositeKey(anyString(), any(String[].class)))
+          .willReturn(ENTITY_COMPOSITE_KEY);
+      given(stub.getState(anyString())).willReturn(new byte[] {});
+
+      assertThrows(
+          EntityNotFoundException.class,
+          () -> registry.mustDelete(TestEntity.class, entity.foo, entity.bar));
+      verifyNoMoreInteractions(stub);
+    }
+
+    @Test
+    void given_existing_entity_with_insufficient_key_parts_then_throw_illegal_argument() {
+      assertThrows(
+          IllegalArgumentException.class, () -> registry.mustDelete(TestEntity.class, entity.foo));
+      verifyNoMoreInteractions(stub);
+    }
+
+    @Test
+    void given_existing_entity_with_complete_key_then_call_delState()
+        throws EntityNotFoundException {
+      given(stub.createCompositeKey(anyString(), any(String[].class)))
+          .willReturn(ENTITY_COMPOSITE_KEY);
+      given(stub.getState(anyString())).willReturn(ENTITY_BUFFER);
+
+      registry.mustDelete(TestEntity.class, entity.foo, entity.bar);
+
+      then(stub).should().getState(ENTITY_COMPOSITE_KEY_STR);
+      then(stub).should().delState(ENTITY_COMPOSITE_KEY_STR);
+      verifyNoMoreInteractions(stub);
+    }
+  }
+
+  @Nested
+  class when_try_delete_with_key_parts {
+
+    @Test
+    void given_empty_ledger_with_insufficient_key_parts_then_throw_illegal_argument() {
+      assertThrows(
+          IllegalArgumentException.class, () -> registry.tryDelete(TestEntity.class, entity.foo));
+      verifyNoMoreInteractions(stub);
+    }
+
+    @Test
+    void given_empty_ledger_with_complete_key_then_return_false_and_do_nothing() {
+      given(stub.createCompositeKey(anyString(), any(String[].class)))
+          .willReturn(ENTITY_COMPOSITE_KEY);
+      given(stub.getState(anyString())).willReturn(new byte[] {});
+
+      boolean result = registry.tryDelete(TestEntity.class, entity.foo, entity.bar);
+
+      assertFalse(result);
+      then(stub).should().getState(ENTITY_COMPOSITE_KEY_STR);
+      verifyNoMoreInteractions(stub);
+    }
+
+    @Test
+    void given_existing_entity_with_insufficient_key_parts_then_throw_illegal_argument() {
+      assertThrows(
+          IllegalArgumentException.class, () -> registry.tryDelete(TestEntity.class, entity.foo));
+      verifyNoMoreInteractions(stub);
+    }
+
+    @Test
+    void given_existing_entity_with_complete_key_then_return_true_and_call_delState() {
+      given(stub.createCompositeKey(anyString(), any(String[].class)))
+          .willReturn(ENTITY_COMPOSITE_KEY);
+      given(stub.getState(anyString())).willReturn(ENTITY_BUFFER);
+
+      boolean result = registry.tryDelete(TestEntity.class, entity.foo, entity.bar);
+
+      assertTrue(result);
+      then(stub).should().getState(ENTITY_COMPOSITE_KEY_STR);
+      then(stub).should().delState(ENTITY_COMPOSITE_KEY_STR);
+      verifyNoMoreInteractions(stub);
+    }
+  }
+
+  @Nested
   class when_readAll {
 
     @Test


### PR DESCRIPTION
Closes #47

## Description

This PR resolves the API asymmetry in the `Registry` class by introducing key-parts-based deletion overloads, allowing developers to delete entries using their entity class type and primary key parts directly.

### Changes

#### `Registry.java`
* Added **`resolveCompositeKey(Class<?> clazz, Object[] keyParts)`**: A private helper method to centralize validation and construction of composite keys.
* Added **`mustDelete(Class<T> clazz, Object... keyParts)`**: Overload to delete an existing entity by type and keys.
* Added **`tryDelete(Class<T> clazz, Object... keyParts)`**: Overload to delete an entity by type and keys if it exists.
* Refactored **`mustRead(Class<T> clazz, Object... keyParts)`** to use the new helper method.

#### `RegistryTest.java`
* Added test suite **`when_must_delete_with_key_parts`** covering parameter verification and deletion logic.
* Added test suite **`when_try_delete_with_key_parts`** covering conditional safe deletion.

### Verification Results
Ran local formatting and unit tests:
```bash
./gradlew spotlessApply
./gradlew clean test
