### PR TITLE
Add lifecycle hooks and plumbing validation to HypernateContract

### DIFF
--- a/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/contract/HypernateContract.java
+++ b/lib/src/main/java/hu/bme/mit/ftsrg/hypernate/contract/HypernateContract.java
@@ -11,10 +11,32 @@ import java.util.*;
 import org.hyperledger.fabric.contract.Context;
 import org.hyperledger.fabric.contract.ContractInterface;
 import org.hyperledger.fabric.shim.ChaincodeStub;
+import org.slf4j.LoggerFactory;
 
-/** Contract base class enriched with default before-/after-transaction notification handling. */
+/**
+ * Contract base interface enriched with default before-/after-transaction notification handling and
+ * middleware chain initialization.
+ *
+ * <p>Implementing classes should generally avoid overriding {@link #createContext(ChaincodeStub)},
+ * {@link #beforeTransaction(Context)}, and {@link #afterTransaction(Context, Object)}, as
+ * overriding these methods without reproducing the base plumbing will break Hypernate's middleware
+ * chain, registry, and caching mechanisms. Instead, use {@link
+ * #onBeforeTransaction(HypernateContext)}, {@link #onAfterTransaction(HypernateContext, Object)},
+ * and {@link #initMiddlewares(ChaincodeStub)} to extend contract behavior.
+ */
 public interface HypernateContract extends ContractInterface {
 
+  /**
+   * Plumbing method: creates the {@link HypernateContext} by initializing the middleware chain,
+   * wrapping it in a context, and subscribing all middlewares in the chain to transaction
+   * notifications.
+   *
+   * <p><strong>Do not override this method.</strong> If custom middleware initialization is
+   * required, override {@link #initMiddlewares(ChaincodeStub)} instead.
+   *
+   * @param fabricStub the fabric chaincode stub
+   * @return the initialized hypernate transaction context
+   */
   @Override
   default Context createContext(ChaincodeStub fabricStub) {
     StubMiddlewareChain mwChain = initMiddlewares(fabricStub);
@@ -23,23 +45,77 @@ public interface HypernateContract extends ContractInterface {
     return ctx;
   }
 
+  /**
+   * Plumbing method: publishes the {@link TransactionBegin} notification and calls the {@link
+   * #onBeforeTransaction(HypernateContext)} hook.
+   *
+   * <p><strong>Do not override this method.</strong> Override {@link
+   * #onBeforeTransaction(HypernateContext)} to implement pre-transaction hooks.
+   *
+   * @param ctx the fabric transaction context
+   */
   @Override
   default void beforeTransaction(Context ctx) {
     if (ctx instanceof HypernateContext hypCtx) {
       hypCtx.notify(new TransactionBegin());
+      onBeforeTransaction(hypCtx);
     } else {
+      LoggerFactory.getLogger(HypernateContract.class)
+          .warn(
+              "beforeTransaction called with non-HypernateContext context instance (type: {}). "
+                  + "This suggests createContext was overridden without preserving Hypernate plumbing. "
+                  + "Hypernate middleware and write-back caches will not function.",
+              ctx.getClass().getName());
       ContractInterface.super.beforeTransaction(ctx);
     }
   }
 
+  /**
+   * Plumbing method: calls the {@link #onAfterTransaction(HypernateContext, Object)} hook and
+   * publishes the {@link TransactionEnd} notification (flushing the write-back cache).
+   *
+   * <p><strong>Do not override this method.</strong> Override {@link
+   * #onAfterTransaction(HypernateContext, Object)} to implement post-transaction hooks.
+   *
+   * @param ctx the fabric transaction context
+   * @param _result the transaction execution result
+   */
   @Override
   default void afterTransaction(Context ctx, Object _result) {
     if (ctx instanceof HypernateContext hypCtx) {
+      onAfterTransaction(hypCtx, _result);
       hypCtx.notify(new TransactionEnd());
     } else {
-      ContractInterface.super.beforeTransaction(ctx);
+      LoggerFactory.getLogger(HypernateContract.class)
+          .warn(
+              "afterTransaction called with non-HypernateContext context instance (type: {}). "
+                  + "This suggests createContext was overridden without preserving Hypernate plumbing. "
+                  + "Hypernate middleware and write-back caches will not function.",
+              ctx.getClass().getName());
+      ContractInterface.super.afterTransaction(ctx, _result);
     }
   }
+
+  /**
+   * Hook method called before a transaction execution, after middlewares have been initialized and
+   * the {@link TransactionBegin} notification has been published.
+   *
+   * <p>Override this method to run custom setup or validation logic before each transaction.
+   *
+   * @param ctx the hypernate transaction context
+   */
+  default void onBeforeTransaction(HypernateContext ctx) {}
+
+  /**
+   * Hook method called after a transaction execution completes, before the {@link TransactionEnd}
+   * notification is published (and thus before the write-back cache is flushed).
+   *
+   * <p>Override this method to run custom cleanup or logging logic after each transaction.
+   *
+   * @param ctx the hypernate transaction context
+   * @param result the result of the transaction execution, or null if void/failed
+   */
+  default void onAfterTransaction(HypernateContext ctx, Object result) {}
 
   /**
    * Initialize the middleware chain.

--- a/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/contract/HypernateContractTest.java
+++ b/lib/src/test/java/hu/bme/mit/ftsrg/hypernate/contract/HypernateContractTest.java
@@ -1,0 +1,146 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+package hu.bme.mit.ftsrg.hypernate.contract;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import hu.bme.mit.ftsrg.hypernate.context.HypernateContext;
+import hu.bme.mit.ftsrg.hypernate.middleware.notification.HypernateNotification;
+import hu.bme.mit.ftsrg.hypernate.middleware.notification.TransactionBegin;
+import hu.bme.mit.ftsrg.hypernate.middleware.notification.TransactionEnd;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.concurrent.Flow.Subscription;
+import org.hyperledger.fabric.contract.Context;
+import org.hyperledger.fabric.shim.ChaincodeStub;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class HypernateContractTest {
+
+  @Mock private ChaincodeStub stub;
+  @Mock private Context plainContext;
+
+  private TestContract contract;
+
+  @BeforeEach
+  void setUp() {
+    contract = new TestContract();
+
+    String pemCert =
+        "-----BEGIN CERTIFICATE-----\n"
+            + "MIIC/zCCAeegAwIBAgIURRdj6Y8640fkGMq1qf1v3GXZWpIwDQYJKoZIhvcNAQEL\n"
+            + "BQAwDzENMAsGA1UEAwwEdGVzdDAeFw0yNjA3MjExNjMxMDFaFw0yNzA3MjExNjMx\n"
+            + "MDFaMA8xDTALBgNVBAMMBHRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK\n"
+            + "AoIBAQCt77mk/XPOA9CAipMNlng+rTEa8yVe1uJ/eSpc80hF+GXOHtE+c423gQBX\n"
+            + "aaJlyVMAefx68dJ86oeKDM/85cMnBlxLzn5r3RVzbqi99/vs+FnAb5XyIcncSd17\n"
+            + "Xm4Zjq2nuoZA/WuEC5GXaqkMW1WAAoiwZDsZO4L8oB2VU/+/izzs3aRxKsjfD45k\n"
+            + "vLByyu5DLhnGN+muHyMMGMPvxS/ZBe9QYxdyxfsEWTsZQ2qvxdDSwBkft0GL6ezE\n"
+            + "z7q1pTbchXi/LE0n/Zper7rZalhSszgXfoMd2gdpnOVF7AGYxrPq/8tYA+u8c8x7\n"
+            + "p/ZLQNfXklA3KcLW7klEqrqNX+3LAgMBAAGjUzBRMB0GA1UdDgQWBBRB2ziW2SfG\n"
+            + "JrhZTTB8/5K5208U6zAfBgNVHSMEGDAWgBRB2ziW2SfGJrhZTTB8/5K5208U6zAP\n"
+            + "BgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCU8JJ/uiSFjMkspQxX\n"
+            + "WTXjH2belXE6pEnXV7zpVYPttapM0+2BQyn+PprPU19Lye5FdUB1L2vFEAu+X7Be\n"
+            + "Z5kW/tDCWcoZ1yExOlyIh6ZPoX97fZ5XxmrFV6zjAbl4NZFPnpS3WsIaUJomL6Xo\n"
+            + "8ymCWYO32IImjVlrs2AydX2ZV9jzEFLF8yMREHxHPsfkukBcISMW2eNw5Dj4Qj7N\n"
+            + "mvk22/swhdu7kAdcv+TpHU0XgfLjej3bAJsb93UVvmeZRYPN2eh9sVVzKoVVUfOA\n"
+            + "KHZFduAMjBvzSw5h1G6xdMA0o14aYXbhN5tpRvVWCjTOAh3yavwCELYv40wHLDFu\n"
+            + "RFWW\n"
+            + "-----END CERTIFICATE-----";
+
+    org.hyperledger.fabric.protos.msp.SerializedIdentity mspIdentity =
+        org.hyperledger.fabric.protos.msp.SerializedIdentity.newBuilder()
+            .setMspid("testMSP")
+            .setIdBytes(com.google.protobuf.ByteString.copyFromUtf8(pemCert))
+            .build();
+    lenient().when(stub.getCreator()).thenReturn(mspIdentity.toByteArray());
+  }
+
+  @Test
+  void should_initialize_context_and_subscribe_middlewares() {
+    Context context = contract.createContext(stub);
+    assertTrue(context instanceof HypernateContext);
+
+    HypernateContext hypCtx = (HypernateContext) context;
+    assertEquals(stub, hypCtx.getFabricStub());
+  }
+
+  @Test
+  void should_trigger_notifications_and_hooks_in_correct_order() {
+    HypernateContext hypCtx = (HypernateContext) contract.createContext(stub);
+    hypCtx.subscribeToNotifications(
+        new Subscriber<HypernateNotification>() {
+          @Override
+          public void onSubscribe(Subscription subscription) {
+            subscription.request(Long.MAX_VALUE);
+          }
+
+          @Override
+          public void onNext(HypernateNotification item) {
+            if (item instanceof TransactionBegin) {
+              contract.callOrder.add("TransactionBegin");
+            } else if (item instanceof TransactionEnd) {
+              contract.callOrder.add("TransactionEnd");
+            }
+          }
+
+          @Override
+          public void onError(Throwable throwable) {}
+
+          @Override
+          public void onComplete() {}
+        });
+
+    contract.beforeTransaction(hypCtx);
+    assertEquals(2, contract.callOrder.size());
+    assertEquals("TransactionBegin", contract.callOrder.get(0));
+    assertEquals("onBeforeTransaction", contract.callOrder.get(1));
+
+    Object result = "testResult";
+    contract.afterTransaction(hypCtx, result);
+    assertEquals(4, contract.callOrder.size());
+    assertEquals("onAfterTransaction", contract.callOrder.get(2));
+    assertEquals("TransactionEnd", contract.callOrder.get(3));
+
+    assertTrue(contract.beforeHookCalled);
+    assertTrue(contract.afterHookCalled);
+    assertEquals(result, contract.afterResult);
+  }
+
+  @Test
+  void should_fallback_when_context_is_not_hypernate_context() {
+    assertDoesNotThrow(() -> contract.beforeTransaction(plainContext));
+    assertDoesNotThrow(() -> contract.afterTransaction(plainContext, "result"));
+
+    assertFalse(contract.beforeHookCalled);
+    assertFalse(contract.afterHookCalled);
+  }
+
+  private static class TestContract implements HypernateContract {
+    boolean beforeHookCalled = false;
+    boolean afterHookCalled = false;
+    Object afterResult = null;
+    final List<String> callOrder = new ArrayList<>();
+
+    @Override
+    public void onBeforeTransaction(HypernateContext ctx) {
+      beforeHookCalled = true;
+      callOrder.add("onBeforeTransaction");
+    }
+
+    @Override
+    public void onAfterTransaction(HypernateContext ctx, Object result) {
+      afterHookCalled = true;
+      afterResult = result;
+      callOrder.add("onAfterTransaction");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Fixes #45.

`HypernateContract` default methods (`createContext`, `beforeTransaction`, `afterTransaction`) handle critical internal plumbing—such as middleware chain setup, transaction notifications (`TransactionBegin`, `TransactionEnd`), and write-back cache flushing. Overriding these methods in subclasses breaks this plumbing and can cause silent data loss.

This PR implements the approved **template method pattern** to make lifecycle extension safe and explicit.

## Key Changes
- **New Lifecycle Hooks:** Added `onBeforeTransaction(HypernateContext ctx)` and `onAfterTransaction(HypernateContext ctx, Object result)` default no-op methods as the intended extension points.
- **Plumbing Protection:**
  - `beforeTransaction`: Publishes `TransactionBegin`, executes `onBeforeTransaction(ctx)`, and logs a warning if `ctx` is not a `HypernateContext`.
  - `afterTransaction`: Executes `onAfterTransaction(ctx, result)`, publishes `TransactionEnd` (flushing the cache), and logs a warning if `ctx` is not a `HypernateContext`.
  - Fixed a copy-paste bug in `afterTransaction` fallback (`super.afterTransaction` instead of `super.beforeTransaction`).
- **Documentation:** Added clear Javadocs detailing plumbing methods vs. user extension hooks.
- **Unit Tests:** Added comprehensive unit tests in `HypernateContractTest` verifying notification/hook execution order and fallback behavior.

## Verification
- Ran `./gradlew test --rerun-tasks` (All 35 unit tests passed).
