### PR TITLE
ci(docs): validate the docs build on PRs

### DIFF
--- a/.github/actions/setup-docs/action.yml
+++ b/.github/actions/setup-docs/action.yml
@@ -1,0 +1,16 @@
+name: Set up docs environment
+description: Set up Python and install the MkDocs dependencies
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+        cache: pip
+        cache-dependency-path: docs/requirements.txt
+
+    - name: Install dependencies
+      run: pip install -r docs/requirements.txt
+      shell: bash

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,0 +1,54 @@
+name: Build Documentation
+
+on:
+  push:
+    branches: ['**']
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs-build.yml'
+      - '.github/actions/setup-docs/**'
+  # No path filter for pull requests: a required status check that is filtered
+  # out never reports, leaving the PR blocked forever. Instead, a paths-filter
+  # step inside the job skips the build steps when no documentation files
+  # changed, so the check always reports (and trivially passes) on unrelated
+  # PRs.
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Documentation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect documentation changes
+        id: changes
+        # dorny/paths-filter v4.0.3, pinned by commit SHA
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - 'mkdocs.yml'
+              - '.github/workflows/docs-build.yml'
+              - '.github/actions/setup-docs/**'
+
+      - name: Set up docs environment
+        if: steps.changes.outputs.docs == 'true'
+        uses: ./.github/actions/setup-docs
+
+      - name: Build documentation
+        if: steps.changes.outputs.docs == 'true'
+        run: mkdocs build --strict

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -7,6 +7,13 @@ on:
     tags:
       - "v*.*.*"
 
+# Serialize deployments: concurrent `mike deploy --push` runs race on the
+# gh-pages ref. Do not cancel an in-progress run — interrupting a half-finished
+# gh-pages push is worse than queueing behind it.
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -18,11 +25,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install dependencies
-        run: pip install -r docs/requirements.txt
+      - name: Set up docs environment
+        uses: ./.github/actions/setup-docs
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
@@ -39,11 +43,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install dependencies
-        run: pip install -r docs/requirements.txt
+      - name: Set up docs environment
+        uses: ./.github/actions/setup-docs
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"

--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -43,10 +43,14 @@ internal link or a page missing from the navigation will fail the build.
 - **Link between pages:** link to the Markdown *file*, not the built URL — for example
   `[Reporting Issues](issues.md)`. MkDocs resolves and validates these links.
 
-## How the Site Is Published
+## How the Site Is Validated and Published
+
+Every pull request runs the **Build Documentation** workflow
+(`.github/workflows/docs-build.yml`), which executes the same `mkdocs build --strict` you run
+locally — a broken link or a page missing from `nav` fails the check before the change can merge.
 
 You do not deploy the site manually. The **Deploy Documentation** workflow
-(`.github/workflows/docs.yml`) handles it:
+(`.github/workflows/docs-deploy.yml`) handles it:
 
 - On every push to `main`, the site is published as the `latest` version.
 - On a `v*.*.*` tag, that release is published as a versioned snapshot.

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -78,8 +78,11 @@ When you open a PR that touches code, the **Build & Test** workflow runs three s
 2. `assemble` — compilation.
 3. `test` — the JUnit test suite.
 
+A separate **Build Documentation** workflow validates the documentation site (`mkdocs build
+--strict`) on every PR, so broken links or navigation errors are caught before merge.
+
 All checks must pass before a PR can be merged. See the [CI/CD guide](../guides/cicd.md) for how to
-read results and troubleshoot failures. Documentation-only changes skip this workflow.
+read results and troubleshoot failures. Documentation-only changes skip the Build & Test workflow.
 
 ## Design-Approval Check
 

--- a/docs/guides/cicd.md
+++ b/docs/guides/cicd.md
@@ -7,6 +7,8 @@ This project uses GitHub Actions for continuous integration and delivery.
 | Workflow         | File                                         | Purpose                                                   |
 | ---------------- | -------------------------------------------- | --------------------------------------------------------- |
 | Build & Test     | `.github/workflows/build.yml`                | Formatting checks, compilation, and tests                 |
+| Build Documentation | `.github/workflows/docs-build.yml`        | Validates the documentation site (`mkdocs build --strict`) |
+| Deploy Documentation | `.github/workflows/docs-deploy.yml`      | Publishes the documentation site via mike                 |
 | Triage Label     | `.github/workflows/triage_label.yml`         | Labels newly opened issues with `needs-triage`            |
 | Design Approval  | `.github/workflows/check_design_approval.yml`| Flags PRs without a linked design/approved issue          |
 | Stale PRs        | `.github/workflows/stale_not_approved.yml`   | Marks and eventually closes stale, non-approved PRs       |
@@ -20,6 +22,29 @@ Documentation-only changes are skipped via path filters.
 
 If a new commit is pushed while a run is already in progress for the same branch, the older run is
 automatically canceled.
+
+## Build Documentation
+
+The Build Documentation workflow runs `mkdocs build --strict` — the same command contributors run
+locally — so a broken internal link or a page missing from `nav` fails the check instead of
+breaking the deployment after merge.
+
+It runs on every pull request, regardless of which files changed. This is deliberate: a required
+status check that is skipped by a path filter never reports its result, which would block the PR
+from merging. Instead, a filter step inside the job detects whether any documentation files
+changed and skips the build steps otherwise, so unrelated PRs pass immediately. On branch pushes
+(before a PR exists), path filters do apply, providing early feedback only when documentation
+files change.
+
+Both this workflow and Deploy Documentation set up their Python environment through the shared
+composite action `.github/actions/setup-docs`.
+
+## Deploy Documentation
+
+The Deploy Documentation workflow publishes the site with [mike](https://github.com/jimporter/mike)
+on pushes to `main` (as the `latest` version) and on `v*.*.*` tags (as a versioned snapshot).
+Deployments are serialized: concurrent runs would race on the `gh-pages` branch, so a new run
+queues behind an in-progress one instead of canceling it.
 
 ## Triage Label
 


### PR DESCRIPTION
## Description

Splits documentation CI into a validating **Build Documentation** workflow (runs on every PR) and a renamed **Deploy Documentation** workflow (`docs.yml` → `docs-deploy.yml` via `git mv`, history preserved), closing the gap where documentation changes merged with zero CI validation and only broke after reaching `main`.

Design as approved in the plan on #131:

- **`docs-build.yml`** – `mkdocs build --strict` with `contents: read`. The `pull_request` trigger is deliberately unfiltered (a required check skipped by a path filter never reports and blocks the PR forever – commented inline); `push` triggers are path-filtered for cheap early feedback.
- **`docs-deploy.yml`** – unchanged jobs plus the previously missing `concurrency` guard (`group: docs-deploy`, `cancel-in-progress: false`) so concurrent `mike deploy --push` runs no longer race on `gh-pages`; queueing beats cancelling a half-finished push.
- **`.github/actions/setup-docs`** – composite action (Python 3.12, pip cache, `pip install -r docs/requirements.txt`) deduplicating the setup steps across all three docs jobs.
- Docs updated to match: workflow table and sections in `docs/guides/cicd.md`, validation description in `docs/contributing/documentation.md`, accurate CI wording in `docs/contributing/pull-requests.md`.

## Evidence

- Self-test on my fork: the branch push triggered the new workflow, which validated this very change – [run 32073707731](https://github.com/aklenik/hypernate/actions/runs/32073707731), success, **15 s** end to end (supporting the unfiltered-trigger cost argument).
- `mkdocs build --strict` and workflow YAML validated locally.

## Stack

Chain: #123 (merged) → this → #137 → #138. #123 was fast-forward merged (hash and signature preserved, see #135), and this diff collapsed to its single commit `b7164d3` automatically – no rebase or force-push was needed, exactly as the stacked-PR setup predicted.

**Merging note (the #135 experiment):** merge with a commit-object-preserving method (fast-forward, per the ruleset's linear-history requirement). Squash or rebase-and-merge would rewrite the SHA and break the successor PRs #137/#138.

## Related issue

Closes #131

## Checklist

- [x] This PR is linked to a `design/approved` issue (required for all changes).
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] I ran `./gradlew build` locally and it passes (formatting, compilation, and tests).
- [x] ~~I added or updated tests where appropriate.~~ *(not applicable – CI/docs change)*
- [x] I updated the documentation where appropriate.
