### PR TITLE
ci: adopt fast-forward merges and document the governance conventions

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -1,0 +1,29 @@
+name: Fast-Forward Merge
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  fast-forward:
+    name: Fast-forward main to the PR head
+    # React only to `/fast-forward` comments made on pull requests by users
+    # with write access to the repository.
+    if: >-
+      github.event.issue.pull_request
+      && contains(github.event.comment.body, '/fast-forward')
+      && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fast forward
+        # sequoia-pgp/fast-forward v1.0.0, pinned by commit SHA because this
+        # workflow holds contents: write
+        uses: sequoia-pgp/fast-forward@ea7628bedcb0b0b96e94383ada458d812fca4979
+        with:
+          merge: true
+          comment: always

--- a/docs/contributing/governance.md
+++ b/docs/contributing/governance.md
@@ -1,0 +1,76 @@
+# Project Governance
+
+This page documents how the maintainers track work and integrate contributions.
+The conventions were agreed in the design discussions of
+[#135](https://github.com/LF-Decentralized-Trust-labs/hypernate/issues/135) and
+[#139](https://github.com/LF-Decentralized-Trust-labs/hypernate/issues/139).
+
+## Work Tracking
+
+Work is tracked on the [Hypernate GitHub Project](https://github.com/orgs/LF-Decentralized-Trust-labs/projects/3) as a **kanban flow** – deliberately not sprints, because a volunteer-maintained project has no plannable capacity.
+
+- **Issues are the work items.**
+  Project views display issues; a pull request surfaces on its issue's card through the *Linked pull requests* field.
+  A dedicated review-pipeline view lists open PRs by review state, so the review queue stays visible alongside the issues.
+- **The assignee is the driver:** the person responsible for moving the item to its next state – chasing reviews, unblocking, or splitting it – not necessarily the person writing every line.
+- **The board must reflect repository reality** (labels, PR state) rather than act as a second tracker; anything that can be automated should be.
+
+## Epics
+
+Epics group issues for the roadmap view, and they follow one core rule: **an epic is a bounded increment within a topic, never the topic itself.**
+A theme like "the registry" never finishes; an epic must have a definition of done and eventually close.
+
+- The eternal, thematic axis is expressed with `area/*` labels, not epics.
+- **Verb-first epic titles** ("Complete…", "Stand up…", "Assemble…") force the definition of done into the name.
+  If an epic cannot be titled this way, it is probably a theme in disguise.
+- **Bugs do not need parents** – they flow through the board on their own with an area label.
+- **An epic needs critical mass** (roughly four issues or more), though maintainers may grant exemptions for larger undertakings that start small.
+  Sub-issue nesting itself is free and does not require the `EPIC` label.
+- **Scope freezes at epic creation.**
+  A new related issue goes to the area label and backlog, not into the open epic, unless the maintainers deliberately re-scope.
+- **No milestones.**
+  Milestones imply plannable capacity; instead, releasing is a topic like any other (`area/release`), and the machinery to publish is built through bounded epics.
+
+## Labels
+
+Namespaces are separated with `/`, and each namespace shares one color family so the board reads at a glance.
+
+| Label | Meaning |
+| ----- | ------- |
+| `needs-triage` | Added automatically to every new issue; awaiting maintainer review. |
+| `design/pending` | The design is under active discussion – please wait before starting work. |
+| `design/approved` | The design is approved; contributions are welcome. |
+| `needs-approved-issue` | Added automatically to a pull request not linked to a `design/approved` issue. |
+| `stale` | Added automatically to a flagged pull request after a period of inactivity. |
+| `EPIC` | A bounded, closeable increment grouping sub-issues (see above). |
+| `area/registry`, `area/middleware`, `area/docs`, `area/release`, `area/governance` | The thematic axis: which part of the project an issue belongs to. |
+
+## Merging Pull Requests
+
+Pull requests are merged by **fast-forward only**: `main` is advanced to the PR's head commit, so the contributor's commits land exactly as authored – same hashes, same GPG signatures.
+
+Why not the standard merge buttons:
+
+- *Squash and merge* creates a new commit signed by GitHub's key instead of the author's.
+- *Rebase and merge* always rewrites the commits and strips their signatures entirely, downgrading them to unverified.
+- *Merge commits* would preserve the original commits but break the linear history that the branch ruleset requires.
+
+Fast-forwarding keeps the history linear **and** verifiable, and it has a pleasant side effect for stacked PRs: when a parent PR merges, the child's diff collapses to its own commits automatically, with no rebase or force-push.
+
+### How a merge happens
+
+A maintainer comments `/fast-forward` on an approved, up-to-date pull request; the [Fast-Forward Merge workflow](../guides/cicd.md#fast-forward-merge) performs the push and reports the result in the PR thread.
+A maintainer can equally perform the same operation locally:
+
+```bash
+git fetch upstream
+git checkout main && git merge --ff-only <branch>
+git push upstream main
+```
+
+GitHub marks the PR as merged automatically when its head commit reaches `main`.
+
+### What this means for contributors
+
+- Keep your branch rebased so it sits exactly on top of `main` – a branch that has drifted cannot be fast-forwarded.
+- Because commits land verbatim, each commit should stand on its own: signed off, GPG-signed if you can, conventionally titled, and buildable.

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -107,5 +107,13 @@ Be ready to:
 - Respond to feedback and push follow-up commits.
 - Keep your branch up to date with `main` if asked.
 
-Once it is approved and all checks are green, a maintainer will merge your contribution.
-Thank you!
+## How Your PR Is Merged
+
+Hypernate merges by **fast-forward only** – your commits land on `main` exactly as you authored them, hashes and signatures intact (see [Project Governance](governance.md#merging-pull-requests) for the rationale).
+Two practical consequences:
+
+- Keep your branch rebased so it sits exactly on top of `main`; a branch that has drifted cannot be fast-forwarded.
+- Because commits land verbatim, each commit in your PR should stand on its own: signed off, conventionally titled, and buildable.
+
+Once your PR is approved and all checks are green, a maintainer triggers the merge by commenting `/fast-forward` on it.
+Thank you for contributing!

--- a/docs/guides/cicd.md
+++ b/docs/guides/cicd.md
@@ -12,6 +12,7 @@ This project uses GitHub Actions for continuous integration and delivery.
 | Triage Label     | `.github/workflows/triage_label.yml`         | Labels newly opened issues with `needs-triage`            |
 | Design Approval  | `.github/workflows/check_design_approval.yml`| Flags PRs without a linked design/approved issue          |
 | Stale PRs        | `.github/workflows/stale_not_approved.yml`   | Marks and eventually closes stale, non-approved PRs       |
+| Fast-Forward Merge | `.github/workflows/fast-forward.yml`       | Merges approved PRs by fast-forwarding `main`             |
 
 ## Build & Test
 
@@ -57,6 +58,12 @@ In these cases, either a maintainer can force rerun the check or you can make a 
 A scheduled daily job marks pull requests carrying the `needs-approved-issue` label as `stale` after 14 days of inactivity and closes them after 60 days.
 PRs labeled `pinned` or `security` are exempt.
 Issues are never affected.
+
+## Fast-Forward Merge
+
+When a maintainer comments `/fast-forward` on an approved pull request, this workflow advances `main` to the PR's head commit.
+The commits land exactly as authored – hashes and GPG signatures preserved – keeping history linear and verifiable (see [Project Governance](../contributing/governance.md#merging-pull-requests) for the policy).
+The workflow only reacts to comments from users with write access.
 
 ## Reading CI Results
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
       - Submitting Pull Requests: contributing/pull-requests.md
       - Contributing with AI Agents: contributing/ai-agents.md
       - Contributing to the Docs: contributing/documentation.md
+      - Project Governance: contributing/governance.md
       - Maintainers: contributing/maintainers.md
   - References:
       - Citing: references/citing.md


### PR DESCRIPTION
## Description

Implements the fast-forward merge flow decided in #135 and documents the governance conventions agreed in the design discussions of #135 and #139. Two commits, one per concern:

**`ci: adopt the fast-forward merge workflow`**

- `sequoia-pgp/fast-forward` pinned by commit SHA (`ea7628be` = v1.0.0), since the workflow holds `contents: write`.
- Triple job guard: the comment is on a PR, contains `/fast-forward`, and the commenter's `author_association` is OWNER/MEMBER/COLLABORATOR.
- `merge: true`, `comment: always` – the result lands in the PR thread as an audit trail.
- @bzp99's question on #135 answered in the docs: merging locally with `git merge --ff-only` remains fully equivalent; the action is additive.

**`docs: document the merge policy and work-tracking conventions`**

- New **Project Governance** page (`docs/contributing/governance.md`, in nav): kanban work tracking with issues as the work items and a review-pipeline view for PRs, the "assignee is the driver" definition, the bounded-epic conventions (verb-first titles, `area/*` labels as the thematic axis, critical mass with exemptions, scope freeze, no milestones), the full label taxonomy (`/`-namespaced, one color family per namespace), and the fast-forward-only merge policy with its rationale.
- Contributor-facing **How Your PR Is Merged** section in the pull-request guide (keep rebased; commits land verbatim, so each should stand on its own).
- The new workflow registered in the CI/CD guide (table + section).

## Scope note

This PR deliberately contains **no operative project changes** – no labels created, no issues re-parented or closed, no board configuration. Per the discussion on #139, the board setup happens in a maintainer meeting and the cleanup pass follows once these policies are merged. #139 therefore stays open; this PR only closes the merge-strategy decision.

## Evidence

- Lint (27 files, 0 issues – the governance page is validated by the very conventions it documents), `mkdocs build --strict`, and workflow YAML all pass locally.
- The fast-forward flow itself already has a live proof: #123 was ff-merged and #136's diff collapsed automatically, as predicted in #135.

## Stack

Chain: #123 (merged) → #136 → #137 → #138 → this. With fast-forward merges the diff collapses to this PR's two commits automatically as the parents land.

**Merging note:** fast-forward, as this PR itself documents. A fitting first candidate for the `/fast-forward` comment once it is approved – merging this PR with the workflow it introduces is the workflow's own acceptance test.

## Related issue

Closes #135

Documents the conventions agreed so far in #139 (which stays open for the board setup and automation follow-ups).

## Checklist

- [x] This PR is linked to a `design/approved` issue (required for all changes).
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] I ran `./gradlew build` locally and it passes (formatting, compilation, and tests).
- [x] ~~I added or updated tests where appropriate.~~ *(not applicable – CI/docs change)*
- [x] I updated the documentation where appropriate.
