### PR TITLE
docs: align list nesting with CommonMark via mdx_truly_sane_lists

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -4,8 +4,10 @@ on:
   push:
     branches: ['**']
     paths:
+      - '**.md'
       - 'docs/**'
       - 'mkdocs.yml'
+      - '.markdownlint-cli2.jsonc'
       - '.github/workflows/docs-build.yml'
       - '.github/actions/setup-docs/**'
   # No path filter for pull requests: a required status check that is filtered
@@ -48,6 +50,9 @@ jobs:
       - name: Set up docs environment
         if: steps.changes.outputs.docs == 'true'
         uses: ./.github/actions/setup-docs
+
+      - name: Lint Markdown
+        run: npx --yes markdownlint-cli2@0.23.2
 
       - name: Build documentation
         if: steps.changes.outputs.docs == 'true'

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,21 @@
+// Configuration for markdownlint-cli2 (also read by the VS Code markdownlint
+// extension). Lint locally with: npx markdownlint-cli2
+{
+  "globs": ["**/*.md"],
+  "ignores": [".venv/**", "site/**", "node_modules/**"],
+  "config": {
+    // Only the rules that guard how Python-Markdown renders the documentation
+    // site are enabled for now; adopting a fuller style ruleset is tracked in
+    // https://github.com/LF-Decentralized-Trust-labs/hypernate/issues/133
+    "default": false,
+
+    // Nested list items must be indented consistently within a list
+    "MD005": true,
+
+    // Unordered lists nest by 2 spaces per level (the markdownlint default),
+    // matching CommonMark/GFM. The docs site renders this correctly via the
+    // mdx_truly_sane_lists override in mkdocs.yml; deeper indents would
+    // collapse into run-on text there. See docs/contributing/documentation.md
+    "MD007": true
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,10 @@ with Gradle. Library source lives in the single `lib` module.
 
 - Docs are Markdown under `docs/` (MkDocs Material). Preview with `mkdocs serve`; validate with
   `mkdocs build --strict` (the site uses strict mode, so broken links fail the build).
+- Indent nested list items by 2 spaces per level, as on GitHub — never 4: the docs site overrides
+  Python-Markdown with `mdx_truly_sane_lists` (see `mkdocs.yml`), under which deeper indents
+  collapse into run-on text. Enforced by `npx markdownlint-cli2` (config in
+  `.markdownlint-cli2.jsonc`); run it before committing Markdown changes.
 
 ## Before opening a pull request
 

--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -43,11 +43,43 @@ internal link or a page missing from the navigation will fail the build.
 - **Link between pages:** link to the Markdown *file*, not the built URL — for example
   `[Reporting Issues](issues.md)`. MkDocs resolves and validates these links.
 
+## Markdown Conventions
+
+### Indent Nested Lists by 2 Spaces
+
+Indent each nesting level of a list by **2 spaces**, exactly as you would on GitHub:
+
+```markdown
+- Parent item
+  - Nested item
+    - Deeply nested item
+```
+
+This "just works" only because the site overrides its renderer.
+[Python-Markdown](https://python-markdown.github.io/) (which MkDocs uses) requires 4 spaces per
+level by default and silently flattens 2-space nesting, even though CommonMark and GFM accept it —
+so lists that looked correct on GitHub used to break on the built site. The
+[`mdx_truly_sane_lists`](https://github.com/radude/mdx_truly_sane_lists) extension configured in
+`mkdocs.yml` aligns the site with the CommonMark behavior; only the indentation rule is overridden
+(`truly_sane: false` keeps every other rendering behavior stock).
+
+Two safety nets exist:
+
+- CI lints all Markdown files with [markdownlint](https://github.com/DavidAnson/markdownlint-cli2)
+  (rule `MD007`, at its default 2-space indent), which fails on deeper indents — under the
+  override, a 4-space-nested item would collapse into run-on text on the site. Run it locally with
+  `npx markdownlint-cli2`; the configuration lives in `.markdownlint-cli2.jsonc` at the repository
+  root.
+- When in doubt, check multi-level lists in the `mkdocs serve` preview rather than trusting the
+  GitHub rendering.
+
 ## How the Site Is Validated and Published
 
 Every pull request runs the **Build Documentation** workflow
-(`.github/workflows/docs-build.yml`), which executes the same `mkdocs build --strict` you run
-locally — a broken link or a page missing from `nav` fails the check before the change can merge.
+(`.github/workflows/docs-build.yml`), which lints the Markdown sources (see
+[Markdown Conventions](#markdown-conventions)) and executes the same `mkdocs build --strict` you
+run locally — a broken link, a page missing from `nav`, or a lint violation fails the check before
+the change can merge.
 
 You do not deploy the site manually. The **Deploy Documentation** workflow
 (`.github/workflows/docs-deploy.yml`) handles it:

--- a/docs/contributing/maintainers.md
+++ b/docs/contributing/maintainers.md
@@ -15,6 +15,6 @@ Below is a table of active Hypernate maintainers.
 - Attila Klenik <attila.klenik@vik.bme.hu>
 - Imre Kocsis <kocsis.imre@vik.bme.hu>
 - [Budapest University of Technology and Economics](https://www.bme.hu/en/)
-    - [Faculty of Electrical Engineering and Informatics](https://www.vik.bme.hu/en/)
-        - [Department of Artificial Intelligence and Systems Engineering](http://www.mit.bme.hu/eng/)
-            - [Critical Systems Research Group](https://ftsrg.mit.bme.hu/en/)
+  - [Faculty of Electrical Engineering and Informatics](https://www.vik.bme.hu/en/)
+    - [Department of Artificial Intelligence and Systems Engineering](http://www.mit.bme.hu/eng/)
+      - [Critical Systems Research Group](https://ftsrg.mit.bme.hu/en/)

--- a/docs/guides/cicd.md
+++ b/docs/guides/cicd.md
@@ -7,7 +7,7 @@ This project uses GitHub Actions for continuous integration and delivery.
 | Workflow         | File                                         | Purpose                                                   |
 | ---------------- | -------------------------------------------- | --------------------------------------------------------- |
 | Build & Test     | `.github/workflows/build.yml`                | Formatting checks, compilation, and tests                 |
-| Build Documentation | `.github/workflows/docs-build.yml`        | Validates the documentation site (`mkdocs build --strict`) |
+| Build Documentation | `.github/workflows/docs-build.yml`        | Lints Markdown and validates the documentation site       |
 | Deploy Documentation | `.github/workflows/docs-deploy.yml`      | Publishes the documentation site via mike                 |
 | Triage Label     | `.github/workflows/triage_label.yml`         | Labels newly opened issues with `needs-triage`            |
 | Design Approval  | `.github/workflows/check_design_approval.yml`| Flags PRs without a linked design/approved issue          |
@@ -25,9 +25,12 @@ automatically canceled.
 
 ## Build Documentation
 
-The Build Documentation workflow runs `mkdocs build --strict` — the same command contributors run
-locally — so a broken internal link or a page missing from `nav` fails the check instead of
-breaking the deployment after merge.
+The Build Documentation workflow runs two checks, both identical to what contributors run locally:
+
+1. `npx markdownlint-cli2` — Markdown conventions, most importantly 2-space list nesting
+   (see the [documentation guide](../contributing/documentation.md#markdown-conventions)).
+2. `mkdocs build --strict` — a broken internal link or a page missing from `nav` fails the check
+   instead of breaking the deployment after merge.
 
 It runs on every pull request, regardless of which files changed. This is deliberate: a required
 status check that is skipped by a path filter never reports its result, which would block the PR

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs-material==9.6.11
 mike==2.1.3
+mdx_truly_sane_lists==1.3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,16 @@ theme:
     - search.share
     - toc.follow
 
+# Python-Markdown requires 4-space nested-list indentation by default and
+# silently flattens the 2-space form that CommonMark/GFM accept. Override it
+# so lists render the same here as on GitHub. truly_sane stays off to keep
+# every other rendering behavior identical to vanilla Python-Markdown.
+# See docs/contributing/documentation.md#markdown-conventions
+markdown_extensions:
+  - mdx_truly_sane_lists:
+      truly_sane: false
+      nested_indent: 2
+
 plugins:
   - search
   - mike:


### PR DESCRIPTION
## Description

Aligns nested-list rendering on the docs site with CommonMark/GFM, per the revised design discussed on #134: instead of documenting and enforcing Python-Markdown's 4-space indentation default, the site's renderer is overridden so the 2-space nesting contributors naturally write renders correctly everywhere.

- **Renderer override:** `mdx_truly_sane_lists` in `mkdocs.yml` with an isolated configuration (`truly_sane: false`, `nested_indent: 2`), so *only* the indentation behavior changes – every other rendering behavior verified identical to vanilla. Pinned in `docs/requirements.txt`.
- **Lint:** `.markdownlint-cli2.jsonc` at the repository root (read identically by the CLI, CI, and the VS Code markdownlint extension), with only `MD005` and `MD007` enabled – `MD007` at its markdownlint **default** 2-space indent. Under the override, a deeper-indented item would collapse into run-on text on the site, so the rule is the guard against exactly that.
- **CI:** a `Lint Markdown` step (version-pinned `npx markdownlint-cli2@0.23.2`) in the Build Documentation workflow from #136, before the strict build.
- **Docs:** new *Markdown Conventions* section in `docs/contributing/documentation.md` documenting the 2-space rule and the override rationale (including why the GitHub diff view cannot reveal the old breakage); cross-reference in `docs/guides/cicd.md`; matching bullet in `AGENTS.md`.
- **Content fix:** the one inconsistent nesting ladder (`docs/contributing/maintainers.md`, the accidental 8-space line from the #123 review) normalized to consistent 2-space. Root `MAINTAINERS.md` and `README.md` needed no changes – their existing 2-space nesting is simply correct under the override.

## Evidence

- Self-test on my fork: [run 32254518182](https://github.com/aklenik/hypernate/actions/runs/32254518182) – pip install including the extension, lint (26 files, 0 issues), and strict build all pass.
- **Rendering-equivalence proof:** the site was built before and after the change and every HTML page compared with normalized whitespace. Only the two pages with deliberate text rewrites differ; every other page – including the 4-level maintainers ladder – renders **byte-identically**. The content flip (4→2 space) and renderer flip cancel exactly, evidencing that the override does only what it claims.
- The spike results that shaped the isolated configuration (default `truly_sane: true` changes loose-list rendering; 4-space content collapses under the override) are documented in the design discussion on #134.

## Stack

Chain: #123 (merged) → #136 → this → #138. Until #136 merges, this diff includes its commit; with fast-forward merges (see #135) the diff collapses to this PR's single commit `e8fc8eb` automatically, with no rebase or force-push – as already demonstrated when #123's merge collapsed #136.

**Merging note (the #135 experiment):** merge by fast-forward (the ruleset's linear-history requirement rules out merge commits). Squash or rebase-and-merge would rewrite the SHA and break the successor PR #138.

## Supersedes #137

This PR replaces #137, which had identical content (same head branch, same commit `e8fc8eb`). #137's base branch was switched to `gh-pages` while attempting to re-trigger its checks; since `gh-pages` shares no history with the head branch, GitHub automatically closed the PR. A closed PR can neither be reopened while the unrelated-history validation fails nor have its base changed ("Cannot change the base branch of a closed pull request" - both the REST and GraphQL APIs refuse), so recovery in place was impossible and this fresh PR is the clean way out.

## Related issue

Closes #134

## Checklist

- [x] This PR is linked to a `design/approved` issue (required for all changes).
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] I ran `./gradlew build` locally and it passes (formatting, compilation, and tests).
- [x] ~~I added or updated tests where appropriate.~~ *(not applicable – docs/lint change)*
- [x] I updated the documentation where appropriate.

